### PR TITLE
Add an arbitrary-sized integer representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,9 @@ dependencies = [
 name = "mavros-int-semantics"
 version = "0.1.0"
 dependencies = [
+ "num-bigint",
  "proptest",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ anyhow = { version = "1.0.87" }
 ark-bn254 = { version = "0.6.0" }
 ark-ff = { version = "0.6.0" }
 ark-std = { version = "0.6.0" }
+num-bigint = { version = "0.4.6" }
 num-traits = { version = "0.2.19" }
 proptest = { version = "1.9" }
 serde = { version = "1.0.204", features = ["derive"] }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "4.5.17", features = ["unstable-v5", "derive"] }
 fixedbitset = { version = "0.4" } # Keep in lockstep with petgraph's transitive version
 inkwell = { version = "0.10.0", features = ["llvm22-1"] }
 itertools = { version = "0.14.0" }
-num-bigint = { version = "0.4" }
+num-bigint.workspace = true
 num-traits = { version = "0.2" }
 petgraph = { version = "0.6.5" } # Cannot bump as it is currently required to be this version by a dependency
 plotters = { version = "0.3.5" }

--- a/compiler/src/compiler/analysis/click_cooper/lattice.rs
+++ b/compiler/src/compiler/analysis/click_cooper/lattice.rs
@@ -4,11 +4,14 @@ use std::sync::{Arc, OnceLock};
 
 use mavros_artifacts::FieldConfig;
 
-use mavros_int_semantics::{self as semantics, CmpOp, Sign};
+use mavros_int_semantics::{self as semantics, CmpOp, IntBits, Sign};
 
-use crate::compiler::ssa::hlssa::{
-    ArithGroup, BinaryArithOpKind, Blob, CastTarget, CmpKind, Constant, MAX_SUPPORTED_SIGNED_BITS,
-    MAX_SUPPORTED_UNSIGNED_BITS, SliceOpDir, Type,
+use crate::compiler::{
+    ssa::hlssa::{
+        ArithGroup, BinaryArithOpKind, Blob, CastTarget, CmpKind, Constant,
+        MAX_SUPPORTED_SIGNED_BITS, MAX_SUPPORTED_UNSIGNED_BITS, SliceOpDir, Type,
+    },
+    util::host_word,
 };
 
 // CONSTNESS
@@ -46,9 +49,8 @@ pub(crate) fn const_join(a: Constness, b: Constness) -> Constness {
 
 pub(crate) fn const_bool(c: &Constant) -> Option<bool> {
     match c {
-        Constant::Int(1, 0) => Some(false),
-        Constant::Int(1, 1) => Some(true),
-        Constant::Int(..) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
+        Constant::Int(v) if v.bits() == 1 => Some(!v.is_zero()),
+        Constant::Int(_) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
     }
 }
 
@@ -60,7 +62,7 @@ pub(crate) fn bool_constant(value: bool) -> Arc<Constant> {
     static FALSE: OnceLock<Arc<Constant>> = OnceLock::new();
     static TRUE: OnceLock<Arc<Constant>> = OnceLock::new();
     let slot = if value { &TRUE } else { &FALSE };
-    slot.get_or_init(|| Arc::new(Constant::Int(1, value as u128)))
+    slot.get_or_init(|| Arc::new(Constant::int(1, value as u128)))
         .clone()
 }
 
@@ -86,9 +88,7 @@ pub(crate) fn eval_binary(
     match (a, b) {
         // A `Constant::Int` is a raw bit pattern and says nothing about how to read itself; the
         // _operation_ decides, and these two folds are the two readings of the same patterns.
-        (Constant::Int(s1, x), Constant::Int(s2, y)) => {
-            fold_int(group, kind.sign(), *s1, *x, *s2, *y)
-        }
+        (Constant::Int(x), Constant::Int(y)) => fold_int(kind, x, y),
         // FIELD-ASSUMPTION: L4-eval
         (Constant::Field(x), Constant::Field(y)) => {
             match group {
@@ -108,8 +108,8 @@ pub(crate) fn eval_binary(
         }
         // Mixed-kind pairs and non-scalar constants do not fold.
         (
-            Constant::Int(..) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
-            Constant::Int(..) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
+            Constant::Int(_) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
+            Constant::Int(_) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
         ) => None,
     }
 }
@@ -125,14 +125,17 @@ fn width_cap(sign: Sign) -> usize {
     }
 }
 
-/// The width a fold may produce a constant at, or `None` if it must decline.
+/// Whether a fold may act on this pair of widths at all.
 ///
 /// The two operands must already be at one width, shifts included. That is not a restriction
 /// invented by this analysis: `hlssa_to_llssa::assert_int_arith_widths` requires _every_ integer
 /// `BinaryArithOp`'s operands to be exactly the width of its result, so a mixed-width pair is IR
 /// that panics downstream, and folding one would mint a constant for a shape nothing may build.
-fn fold_width(sign: Sign, s1: usize, s2: usize) -> Option<usize> {
-    ((1..=width_cap(sign)).contains(&s1) && s1 == s2).then_some(s1)
+///
+/// This is a gate and nothing more: the width a fold happens at is the one its operands carry. The
+/// model panics on a pair it does not admit, and this analysis declines instead.
+fn foldable_widths(sign: Sign, s1: usize, s2: usize) -> bool {
+    (1..=width_cap(sign)).contains(&s1) && s1 == s2
 }
 
 /// Fold a pair of raw patterns under one reading.
@@ -145,17 +148,12 @@ fn fold_width(sign: Sign, s1: usize, s2: usize) -> Option<usize> {
 /// `Shl` is not an exception though it may look like one. A left shift that pushes bits off the top
 /// **wraps**, and Noir reports an error only when the _amount_ reaches the width, so the model
 /// accepts it and returns the truncated value.
-fn fold_int(
-    group: ArithGroup,
-    sign: Sign,
-    s1: usize,
-    x: u128,
-    s2: usize,
-    y: u128,
-) -> Option<Constant> {
-    let bits = fold_width(sign, s1, s2)?;
-    let v = semantics::eval(group.into(), sign, bits, x, bits, y).value()?;
-    Some(Constant::Int(bits, v))
+fn fold_int(kind: BinaryArithOpKind, x: &IntBits, y: &IntBits) -> Option<Constant> {
+    if !foldable_widths(kind.sign(), x.bits(), y.bits()) {
+        return None;
+    }
+    let v = semantics::eval(kind.into(), x, y).value()?;
+    Some(Constant::Int(v))
 }
 
 /// Folds a constant comparison operation.
@@ -164,16 +162,17 @@ fn fold_int(
 /// as magnitudes and `SLt` as two's complement. `Eq` compares the patterns themselves, so it needs
 /// no reading at all — only equal widths.
 pub(crate) fn eval_cmp(kind: CmpKind, a: &Constant, b: &Constant) -> Option<Constant> {
-    let res = |v: bool| Some(Constant::Int(1, v as u128));
+    let res = |v: bool| Some(Constant::int(1, v as u128));
 
     match (kind, a, b) {
         // `Eq` needs no reading at all, but it is routed through the model with the rest so that
         // "how are two patterns compared" has exactly one answer in this compiler.
-        (kind, Constant::Int(s1, x), Constant::Int(s2, y)) if s1 == s2 => {
-            let (op, sign) = cmp_reading(kind);
-            (1..=width_cap(sign))
-                .contains(s1)
-                .then(|| semantics::cmp(op, sign, *s1, *x, *y))
+        (kind, Constant::Int(x), Constant::Int(y)) if x.bits() == y.bits() => {
+            let op = CmpOp::from(kind);
+            let cap = width_cap(op.sign().unwrap_or(Sign::Unsigned));
+            (1..=cap)
+                .contains(&x.bits())
+                .then(|| x.compare(op, y))
                 .and_then(res)
         }
         (CmpKind::Eq, Constant::Field(x), Constant::Field(y)) => res(x == y),
@@ -181,23 +180,9 @@ pub(crate) fn eval_cmp(kind: CmpKind, a: &Constant, b: &Constant) -> Option<Cons
         // Width-mismatched, mixed-kind, and non-scalar comparisons do not fold
         (
             CmpKind::Eq | CmpKind::ULt | CmpKind::SLt,
-            Constant::Int(..) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
-            Constant::Int(..) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
+            Constant::Int(_) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
+            Constant::Int(_) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_),
         ) => None,
-    }
-}
-
-/// How a comparison reads its operands, in the model's vocabulary.
-///
-/// Spelled out rather than defaulted so that a new [`CmpKind`] is a compile error here instead of
-/// silently acquiring whichever reading the fallback happened to name.
-fn cmp_reading(kind: CmpKind) -> (CmpOp, Sign) {
-    match kind {
-        // `Eq` compares the patterns themselves, so its reading is inert. `Unsigned` is the one
-        // that leaves them alone, and it keeps `Eq` out of the signed width cap it need not obey.
-        CmpKind::Eq => (CmpOp::Eq, Sign::Unsigned),
-        CmpKind::ULt => (CmpOp::Lt, Sign::Unsigned),
-        CmpKind::SLt => (CmpOp::Lt, Sign::Signed),
     }
 }
 
@@ -215,42 +200,45 @@ pub(crate) fn eval_cast(target: &CastTarget, v: &Constant, field: FieldConfig) -
         | CastTarget::Map(_) => None,
         CastTarget::Field => match v {
             // FIELD-ASSUMPTION: L4-eval
-            Constant::Int(_, x) => Some(Constant::Field(field.constant(*x))),
+            Constant::Int(x) => Some(Constant::Field(field.constant(host_word(x)))),
             Constant::Field(_) => Some(v.clone()),
             Constant::FnPtr(_) | Constant::Blob(_) => None,
         },
-        CastTarget::Int(n) => int_cast_bits(v, *n).map(|bits| Constant::Int(*n, bits)),
+        CastTarget::Int(n) => int_cast_bits(v, *n).map(Constant::Int),
     }
 }
 
-/// Extracts the low `n` bits of a constant's value and returns them as a raw u128 magnitude, or
-/// `None` if the constant is not numeric.
-fn int_cast_bits(v: &Constant, n: usize) -> Option<u128> {
+/// Extracts the low `n` bits of a constant's value as an `n`-bit pattern, or `None` if the
+/// constant is not numeric.
+fn int_cast_bits(v: &Constant, n: usize) -> Option<IntBits> {
     if !(1..=MAX_SUPPORTED_UNSIGNED_BITS).contains(&n) {
         return None;
     }
     match v {
-        Constant::Int(_, x) => Some(semantics::cast_int(*x, n)),
+        Constant::Int(x) => Some(x.cast(n)),
         // FIELD-ASSUMPTION: L4-decompose
         Constant::Field(f) => {
             let limbs = f.into_bigint().0;
-            Some(semantics::field_limbs_to_int(&limbs, n))
+            Some(IntBits::from_field_limbs(&limbs, n))
         }
         Constant::FnPtr(_) | Constant::Blob(_) => None,
     }
 }
 
 /// Folds a constant sign extension operation.
+///
+/// The width extended _from_ is the constant's own, never the instruction's `from_bits`: filling
+/// from the wrong bit would mint a wrong constant silently. `analysis::types` holds the two to each
+/// other, so a disagreeing pair is unreachable in IR that type-checks; declining rather than
+/// asserting keeps this analysis's rule that a shape it cannot account for produces no constant,
+/// and leaves the loud failure at the one site that owns it.
 pub(crate) fn eval_sext(v: &Constant, from_bits: usize, to_bits: usize) -> Option<Constant> {
     if from_bits == 0 || from_bits > to_bits || to_bits > MAX_SUPPORTED_UNSIGNED_BITS {
         return None;
     }
     match v {
-        Constant::Int(_, x) => Some(Constant::Int(
-            to_bits,
-            semantics::sign_extend(*x, from_bits, to_bits),
-        )),
-        Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
+        Constant::Int(x) if x.bits() == from_bits => Some(Constant::Int(x.sign_extend(to_bits))),
+        Constant::Int(_) | Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
     }
 }
 
@@ -259,36 +247,47 @@ pub(crate) fn eval_sext(v: &Constant, from_bits: usize, to_bits: usize) -> Optio
 /// `BitRange` keeps the source type (it is the IR's truncation primitive), so only the payload
 /// bits change and a field source folds to a field.
 ///
-/// A **field** source is read through [`semantics::field_limbs_to_int`], the same canonical LE
+/// A **field** source is read through [`IntBits::from_field_limbs`], the same canonical LE
 /// decomposition that `int_cast_bits` uses for the `Field -> Int` cast, and so is bounded
 /// by what that can express: a window reaching past bit [`MAX_SUPPORTED_UNSIGNED_BITS`] declines
 /// rather than answering the low bits of one that does fit.
 ///
-/// [`semantics::bit_range`] is itself total and answers `0` for an offset past the width. Declining
-/// there instead is this analysis keeping out of minting a constant for a shape nothing builds, on
-/// the same terms as every other refusal here.
+/// [`IntBits::bit_range`] is total in its **offset** as a pattern shifted past its own width is
+/// empty, so declining a large one is this analysis avoiding minting a constant in a place it would
+/// be essentially useless.
+///
+/// The **zero** width is different as an empty window is not a pattern and asking for one panics,
+/// so it is refused rather than declined-by-convention. `analysis::types` rejects such a `BitRange`
+/// outright, which makes this unreachable in IR that type-checks.
 pub(crate) fn eval_bit_range(
     v: &Constant,
     offset: usize,
     width: usize,
     field: FieldConfig,
 ) -> Option<Constant> {
-    if offset >= MAX_SUPPORTED_UNSIGNED_BITS {
+    if width == 0 || offset >= MAX_SUPPORTED_UNSIGNED_BITS {
         return None;
     }
     match v {
-        Constant::Int(s, x) => Some(Constant::Int(*s, semantics::bit_range(*x, offset, width))),
+        // `BitRange` keeps the source type, so the window is widened back: the model answers a
+        // `width`-wide pattern, where the IR wants the same number at the source's width.
+        Constant::Int(x) if offset.saturating_add(width) <= x.bits() => {
+            Some(Constant::Int(x.bit_range(offset, width).cast(x.bits())))
+        }
+        Constant::Int(_) => None,
 
         // FIELD-ASSUMPTION: L4-decompose
         Constant::Field(f) => {
+            // Only an upper bound: `width` is at least one by the refusal above, so `read` is too
+            // and a lower bound here would be dead.
             let read = offset.checked_add(width)?;
-            if !(1..=MAX_SUPPORTED_UNSIGNED_BITS).contains(&read) {
+            if read > MAX_SUPPORTED_UNSIGNED_BITS {
                 return None;
             }
             let limbs = f.into_bigint().0;
-            let low = semantics::field_limbs_to_int(&limbs, read);
-            let extracted = semantics::bit_range(low, offset, width);
-            Some(Constant::Field(field.constant(extracted)))
+            let low = IntBits::from_field_limbs(&limbs, read);
+            let extracted = low.bit_range(offset, width);
+            Some(Constant::Field(field.constant(host_word(&extracted))))
         }
 
         Constant::FnPtr(_) | Constant::Blob(_) => None,
@@ -298,7 +297,7 @@ pub(crate) fn eval_bit_range(
 /// Folds a constant binary negation.
 pub(crate) fn eval_not(v: &Constant) -> Option<Constant> {
     match v {
-        Constant::Int(s, x) => Some(Constant::Int(*s, semantics::not(*x, *s))),
+        Constant::Int(x) => Some(Constant::Int(x.complement())),
         Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
     }
 }
@@ -317,7 +316,7 @@ const AGGREGATE_FOLD_CAP: usize = 1 << 12;
 /// Reads a constant integer index as a `usize`, or `None` if it is non-integer or too large.
 fn const_index(index: &Constant) -> Option<usize> {
     match index {
-        Constant::Int(_, x) => usize::try_from(*x).ok(),
+        Constant::Int(x) => usize::try_from(x).ok(),
         Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
     }
 }
@@ -359,7 +358,7 @@ pub(crate) fn eval_slice_len(slice: &Constant) -> Option<Constant> {
     };
 
     // The result is always a u32 according to the type system.
-    Some(Constant::Int(32, blob.len() as u128))
+    Some(Constant::int(32, blob.len() as u128))
 }
 
 /// Folds a `SlicePush`: a constant aggregate extended by `values` at the front or back.
@@ -460,13 +459,13 @@ pub(crate) fn eval_mk_repeated(
 
 #[cfg(test)]
 mod tests {
-    use mavros_int_semantics::{Outcome, corners, decode_signed, encode_signed};
+    use mavros_int_semantics::{Outcome, SignedValue, corners};
 
     use super::*;
 
     /// An `i8` constant, written as the value it denotes rather than its raw bits.
     fn i8c(v: i128) -> Constant {
-        Constant::Int(8, encode_signed(8, v))
+        Constant::Int(IntBits::from_signed(8, &SignedValue::from(v)))
     }
 
     /// Every arithmetic group, so a new one is a compile error here rather than a silent gap in
@@ -503,27 +502,29 @@ mod tests {
         for group in ALL_GROUPS {
             for signed in [false, true] {
                 let kind = BinaryArithOpKind::with_sign(group, signed);
-                let sign = kind.sign();
 
-                for &bits in corners::widths_for(sign.is_signed()) {
+                for &bits in corners::widths_for(kind.is_signed()) {
                     for &x in &corners::values(bits) {
                         for &y in &corners::values(bits) {
-                            let want = semantics::eval(group.into(), sign, bits, x, bits, y);
+                            // `corners` deals in host words, so the pair is built once and both the
+                            // model and the folder are asked about the same two patterns.
+                            let (x, y) = (IntBits::from_u128(bits, x), IntBits::from_u128(bits, y));
+                            let want = semantics::eval(kind.into(), &x, &y);
                             let got = eval_binary(
                                 kind,
-                                &Constant::Int(bits, x),
-                                &Constant::Int(bits, y),
+                                &Constant::Int(x.clone()),
+                                &Constant::Int(y.clone()),
                                 field,
                             );
 
-                            let ctx = format!("{kind:?} {bits} {x} {y}");
+                            let ctx = format!("{kind:?} {bits} {x:?} {y:?}");
                             match (want, got) {
                                 (_, None) => {}
                                 (Outcome::Rejected(why), Some(folded)) => panic!(
                                     "{ctx}: folded to {folded:?} an input the model rejects ({why:?}), deleting a rejection Noir requires"
                                 ),
-                                (Outcome::Value(v), Some(Constant::Int(s, raw))) => {
-                                    assert_eq!((s, raw), (bits, v), "{ctx}: wrong fold");
+                                (Outcome::Value(v), Some(Constant::Int(folded))) => {
+                                    assert_eq!(folded, v, "{ctx}: wrong fold");
                                     folds += 1;
                                 }
                                 (Outcome::Value(_), Some(other)) => {
@@ -541,8 +542,8 @@ mod tests {
                     assert!(
                         eval_binary(
                             kind,
-                            &Constant::Int(bits, 1),
-                            &Constant::Int(other, 1),
+                            &Constant::int(bits, 1),
+                            &Constant::int(other, 1),
                             field
                         )
                         .is_none(),
@@ -562,7 +563,11 @@ mod tests {
     /// `None` means the fold was refused.
     fn fold(kind: BinaryArithOpKind, a: i128, b: i128) -> Option<i128> {
         match eval_binary(kind, &i8c(a), &i8c(b), FieldConfig::bn254()) {
-            Some(Constant::Int(s, raw)) => Some(decode_signed(s, raw)),
+            // Back to an `i128` so the expectations below stay written as plain numbers; every
+            // reading of an 8-bit pattern fits one by a wide margin.
+            Some(Constant::Int(pattern)) => {
+                Some(i128::try_from(&pattern.to_signed()).expect("an 8-bit reading fits an i128"))
+            }
             Some(other) => panic!("expected a signed constant, got {other:?}"),
             None => None,
         }
@@ -606,7 +611,8 @@ mod tests {
         assert_eq!(fold(SShl, -8, 1), Some(-16));
         assert_eq!(fold(SShl, 1, 6), Some(64));
         // 1 << 7 is 128, one past `i8::MAX`, so it wraps to `i8::MIN`. Two positive operands
-        // producing a negative result is the case a `fits_signed` gate used to refuse.
+        // producing a negative result is exactly the case a `fits_signed` gate would refuse, and
+        // a left shift owes no such gate.
         assert_eq!(fold(SShl, 1, 7), Some(-128));
         assert_eq!(fold(SShl, 2, 6), Some(-128));
         // Everything shifted out: `-16` is 0xF0, and 0xF0 << 4 keeps nothing.
@@ -622,15 +628,15 @@ mod tests {
         let fold_u8 = |a: u128, b: u128| {
             eval_binary(
                 UShl,
-                &Constant::Int(8, a),
-                &Constant::Int(8, b),
+                &Constant::int(8, a),
+                &Constant::int(8, b),
                 FieldConfig::bn254(),
             )
         };
-        assert_eq!(fold_u8(40, 1), Some(Constant::Int(8, 80)));
+        assert_eq!(fold_u8(40, 1), Some(Constant::int(8, 80)));
         // 40 << 3 is 320, which keeps only its low eight bits.
-        assert_eq!(fold_u8(40, 3), Some(Constant::Int(8, 64)));
-        assert_eq!(fold_u8(255, 7), Some(Constant::Int(8, 128)));
+        assert_eq!(fold_u8(40, 3), Some(Constant::int(8, 64)));
+        assert_eq!(fold_u8(255, 7), Some(Constant::int(8, 128)));
         // The amount is still a hard refusal.
         assert_eq!(fold_u8(1, 8), None);
     }
@@ -665,15 +671,98 @@ mod tests {
         // the tag existed, this pair was "mixed" and did not fold at all, which cost the constant
         // propagation that collapses whole chains.
         let f = FieldConfig::bn254();
-        let pair = |kind| eval_binary(kind, &Constant::Int(8, 0xFB), &Constant::Int(8, 0x02), f);
+        let pair = |kind| eval_binary(kind, &Constant::int(8, 0xFB), &Constant::int(8, 0x02), f);
         // 0xFB is -5 read as two's complement and 251 read as a magnitude.
         // -5 / 2 == -2 (0xFE); 251 / 2 == 125 (0x7D).
-        assert_eq!(pair(BinaryArithOpKind::SDiv), Some(Constant::Int(8, 0xFE)));
-        assert_eq!(pair(BinaryArithOpKind::UDiv), Some(Constant::Int(8, 0x7D)));
+        assert_eq!(pair(BinaryArithOpKind::SDiv), Some(Constant::int(8, 0xFE)));
+        assert_eq!(pair(BinaryArithOpKind::UDiv), Some(Constant::int(8, 0x7D)));
 
         // The same for a comparison: -5 < 2 but 251 > 2.
-        let cmp = |kind| eval_cmp(kind, &Constant::Int(8, 0xFB), &Constant::Int(8, 0x02));
-        assert_eq!(cmp(CmpKind::SLt), Some(Constant::Int(1, 1)));
-        assert_eq!(cmp(CmpKind::ULt), Some(Constant::Int(1, 0)));
+        let cmp = |kind| eval_cmp(kind, &Constant::int(8, 0xFB), &Constant::int(8, 0x02));
+        assert_eq!(cmp(CmpKind::SLt), Some(Constant::int(1, 1)));
+        assert_eq!(cmp(CmpKind::ULt), Some(Constant::int(1, 0)));
+    }
+
+    #[test]
+    fn a_sign_extension_folds_from_the_constants_own_width() {
+        // `from_bits` is the instruction's copy of a width the operand already carries.
+        // `analysis::types` rejects a disagreeing pair outright, so the fold's own job is only to
+        // decline one rather than mint a constant filled from the wrong bit.
+        let byte = Constant::int(8, 0x80);
+        assert_eq!(
+            eval_sext(&byte, 8, 16),
+            Some(Constant::int(16, 0xFF80)),
+            "the sign bit of an eight-bit pattern is bit 7"
+        );
+        assert_eq!(
+            eval_sext(&byte, 16, 16),
+            None,
+            "an eight-bit constant is not a sixteen-bit one, whatever the instruction says"
+        );
+    }
+
+    #[test]
+    fn an_empty_bit_range_declines_rather_than_panicking() {
+        // An empty window is not a pattern, so `IntBits::bit_range` panics on one rather than
+        // answering zero. `analysis::types` rejects such a `BitRange` before this is reached, but
+        // the fold must not be the thing that discovers it -- and the *field* arm is the one that
+        // would, since its own `1..=MAX` guard is on `offset + width` and a non-zero offset carries
+        // a zero width straight past it.
+        let f = FieldConfig::bn254();
+        for source in [Constant::int(16, 0xABCD), Constant::Field(f.constant(7u64))] {
+            for offset in [0usize, 5] {
+                assert_eq!(
+                    eval_bit_range(&source, offset, 0, f),
+                    None,
+                    "a zero-width window of {source:?} at offset {offset}"
+                );
+            }
+        }
+
+        // And a one-bit window still folds, so the guard above rejects the empty case only.
+        assert_eq!(
+            eval_bit_range(&Constant::int(16, 0xABCD), 5, 1, f),
+            Some(Constant::int(16, 0)),
+            "bit 5 of 0xABCD is clear"
+        );
+        assert_eq!(
+            eval_bit_range(&Constant::int(16, 0xABCD), 6, 1, f),
+            Some(Constant::int(16, 1)),
+            "bit 6 of 0xABCD is set"
+        );
+    }
+
+    #[test]
+    fn a_bit_range_folds_against_the_constants_own_width() {
+        // The window's bound is read off the constant, the way `eval_sext`'s width is. A window
+        // that reaches past what the operand carries is IR `analysis::types` rejects, so folding
+        // one would mint a constant for a shape nothing builds -- and `cast` would reserve limbs
+        // for the width asked of it on the way.
+        let f = FieldConfig::bn254();
+        let byte = Constant::int(8, 0xAB);
+
+        assert_eq!(
+            eval_bit_range(&byte, 0, 8, f),
+            Some(byte.clone()),
+            "the whole of an eight-bit constant is itself"
+        );
+        assert_eq!(
+            eval_bit_range(&byte, 4, 4, f),
+            Some(Constant::int(8, 0xA)),
+            "the top nibble, right-aligned and held at the source's width"
+        );
+
+        // Past the end, by the width and by the offset in turn, and by a sum that saturates.
+        assert_eq!(
+            eval_bit_range(&byte, 0, 9, f),
+            None,
+            "wider than the source"
+        );
+        assert_eq!(eval_bit_range(&byte, 5, 4, f), None, "reaches past the top");
+        assert_eq!(
+            eval_bit_range(&byte, 1, usize::MAX, f),
+            None,
+            "a window whose end does not fit a usize"
+        );
     }
 }

--- a/compiler/src/compiler/analysis/click_cooper/test.rs
+++ b/compiler/src/compiler/analysis/click_cooper/test.rs
@@ -217,10 +217,10 @@ fn scalar_fold_is_the_single_classifier() {
 #[test]
 fn equal_constants_are_congruent() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c2 = ssa.add_const(Constant::Int(32, 2));
-    let c3 = ssa.add_const(Constant::Int(32, 3));
-    let c4 = ssa.add_const(Constant::Int(32, 4));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c2 = ssa.add_const(Constant::int(32, 2));
+    let c3 = ssa.add_const(Constant::int(32, 3));
+    let c4 = ssa.add_const(Constant::int(32, 4));
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -495,7 +495,7 @@ fn slice_ops_are_value_numbered() {
 #[test]
 fn phi_congruence_excludes_dead_edges() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (x, y, p, q) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -567,9 +567,9 @@ fn phi_distinguished_when_both_edges_live() {
 #[test]
 fn loop_carried_parallel_induction_is_congruent() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, j, lt, i2, j2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -770,9 +770,9 @@ fn leader_never_crosses_incomparable_branches() {
 #[test]
 fn leader_of_constant_class_is_the_interned_constant() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c2 = ssa.add_const(Constant::Int(32, 2));
-    let c3 = ssa.add_const(Constant::Int(32, 3));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c2 = ssa.add_const(Constant::int(32, 2));
+    let c3 = ssa.add_const(Constant::int(32, 3));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let a = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -798,7 +798,7 @@ fn leader_of_constant_class_is_the_interned_constant() {
 #[test]
 fn assert_eq_const_is_conditional_not_unconditional() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let x = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -825,14 +825,14 @@ fn assert_eq_const_is_conditional_not_unconditional() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(after, 0), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // ... and, at index granularity, in the asserting block itself _after_ the assert (the assert is
     // instruction 0, so the terminator at index 1 sees the pin) ...
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // ... but never at the assert's own index, where folding `x` would vacuum the constraint.
     assert_eq!(
@@ -864,14 +864,14 @@ fn assert_bool_is_conditional() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(after, 0), b)
             .as_deref(),
-        Some(&Constant::Int(1, 1))
+        Some(&Constant::int(1, 1))
     );
     // Index granularity: the bool pin also holds after the `Assert` (instruction 0) in its own
     // block, but not at the assert's own index.
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), b)
             .as_deref(),
-        Some(&Constant::Int(1, 1))
+        Some(&Constant::int(1, 1))
     );
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), b),
@@ -1129,7 +1129,7 @@ fn asserted_leader_respects_dominance_fanout() {
 #[test]
 fn asserted_leader_none_without_equality() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (x, z) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1150,7 +1150,7 @@ fn asserted_leader_none_without_equality() {
     // Sanity: the constant pin is recorded as an `asserted_const`, not an equality.
     assert_eq!(
         cc.asserted_const(fid, p1, x).as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // So `x` has no asserted-equal leader, and the untouched `z` has none anywhere.
     assert_eq!(cc.asserted_leader(fid, p1, x), None);
@@ -1433,7 +1433,7 @@ fn witness_forward_unions_hint_and_value_of_reads() {
 #[test]
 fn post_dominance_not_propagated_at_block_granularity() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let x = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1468,12 +1468,12 @@ fn post_dominance_not_propagated_at_block_granularity() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(mid, 0), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(entry_id, 0), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // In the asserting block, index granularity still recovers it _after_ the assert (index 0), but
     // not at the assert's own index — in either channel (the assert is `tail`'s first instruction,
@@ -1481,7 +1481,7 @@ fn post_dominance_not_propagated_at_block_granularity() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(tail, 1), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(cc.asserted_const(fid, ProgramPoint::new(tail, 0), x), None);
     assert_eq!(
@@ -1503,10 +1503,10 @@ fn post_dominance_not_propagated_at_block_granularity() {
 #[test]
 fn post_dominating_assert_unsound_for_loop_carried_value() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let s = ssa.fresh_value();
     let (v, lt, v1) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
@@ -1572,7 +1572,7 @@ fn post_dominating_assert_unsound_for_loop_carried_value() {
         assert_eq!(
             cc.anticipated_const(fid, ProgramPoint::new(bid, 0), s)
                 .as_deref(),
-            Some(&Constant::Int(32, 5)),
+            Some(&Constant::int(32, 5)),
             "stable value must be anticipated in loop block {bid:?}"
         );
     }
@@ -1580,7 +1580,7 @@ fn post_dominating_assert_unsound_for_loop_carried_value() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(after, 1), v)
             .as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
 }
 
@@ -1589,7 +1589,7 @@ fn post_dominating_assert_unsound_for_loop_carried_value() {
 #[test]
 fn assert_on_one_branch_does_not_post_dominate() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let cond = ssa.fresh_value();
     let x = ssa.fresh_value();
 
@@ -1637,7 +1637,7 @@ fn assert_on_one_branch_does_not_post_dominate() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(then_b, 1), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(then_b, 0), x),
@@ -1652,8 +1652,8 @@ fn assert_on_one_branch_does_not_post_dominate() {
 #[test]
 fn anticipated_fact_gated_on_scope() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (x, v) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1686,7 +1686,7 @@ fn anticipated_fact_gated_on_scope() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(mid, 1), v)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // ...but at `entry` — which `tail` equally post-dominates — `def(v) = mid` does not dominate,
     // so the scope gate withholds it.
@@ -1702,7 +1702,7 @@ fn anticipated_fact_gated_on_scope() {
 #[test]
 fn no_exit_path_assert_contributes_nothing() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (p, x) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1745,8 +1745,8 @@ fn no_exit_path_assert_contributes_nothing() {
 #[test]
 fn anticipated_gains_from_constant_branch() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c_true = ssa.add_const(Constant::int(1, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let x = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1777,7 +1777,7 @@ fn anticipated_gains_from_constant_branch() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(entry_id, 0), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // The dominance channel is untouched: `then_b` still does not _dominate_ anything here (the
     // static `else` edge into `merge` remains), so the already-ran direction stays empty...
@@ -1808,8 +1808,8 @@ fn anticipated_const_in_gains_from_pinned_branch() {
     let main_id = ssa.get_unique_entrypoint_id();
     let g = ssa.add_function("g".to_string());
     let (p, x, x0) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c_true = ssa.add_const(Constant::int(1, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
 
     let g_entry = {
         let hf = ssa.get_function_mut(g);
@@ -1861,7 +1861,7 @@ fn anticipated_const_in_gains_from_pinned_branch() {
     // — the caller passes its own free parameter).
     assert_eq!(
         cc.anticipated_const_in(g, &ctx, pp, x).as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
 }
 
@@ -1882,8 +1882,8 @@ fn anticipated_gains_from_dead_back_edge() {
         ssa.fresh_value(),
         ssa.fresh_value(),
     );
-    let c_false = ssa.add_const(Constant::Int(1, 0));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c_false = ssa.add_const(Constant::int(1, 0));
+    let c5 = ssa.add_const(Constant::int(32, 5));
 
     // `g(a) = a + fresh_witness`: nondeterministic, so no invariance rule — neither rule-3 form
     // (pure-op or det-call) nor a congruence witness — can admit its result; its stability rides on
@@ -1946,7 +1946,7 @@ fn anticipated_gains_from_dead_back_edge() {
     assert_eq!(
         cc.anticipated_const(main_id, ProgramPoint::new(header, 1), r)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // The dominance channel still owes nothing before the assert runs.
     assert_eq!(
@@ -1957,7 +1957,7 @@ fn anticipated_gains_from_dead_back_edge() {
     assert_eq!(
         cc.asserted_const(main_id, ProgramPoint::new(after, 1), r)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
 }
 
@@ -1980,7 +1980,7 @@ fn live_back_edge_keeps_call_result_unstable() {
         ssa.fresh_value(),
         ssa.fresh_value(),
     );
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
 
     // `g(a) = a + fresh_witness`: nondeterministic, so no invariance rule can admit its result.
     {
@@ -2049,10 +2049,10 @@ fn live_back_edge_keeps_call_result_unstable() {
 fn anticipated_finality_gains_from_pruned_back_path() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
-    let c_false = ssa.add_const(Constant::Int(1, 0));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
+    let c_false = ssa.add_const(Constant::int(1, 0));
     let (v, lt, v1) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2103,7 +2103,7 @@ fn anticipated_finality_gains_from_pruned_back_path() {
     assert_eq!(
         cc.anticipated_const(main_id, ProgramPoint::new(c_block, 0), v)
             .as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
     // Inside the live loop the executable back-reach is real in both views: no fact.
     assert_eq!(
@@ -2125,8 +2125,8 @@ fn anticipated_finality_gains_from_pruned_back_path() {
 #[test]
 fn pruned_build_keeps_static_post_dominance_fact() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_false = ssa.add_const(Constant::Int(1, 0));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c_false = ssa.add_const(Constant::int(1, 0));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (p, x) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2165,7 +2165,7 @@ fn pruned_build_keeps_static_post_dominance_fact() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(stuck, 0), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // The dominance channel owes nothing: the assert has not run when control is at `stuck`.
     assert_eq!(cc.asserted_const(fid, ProgramPoint::new(stuck, 0), x), None);
@@ -2182,8 +2182,8 @@ fn pruned_build_keeps_static_post_dominance_fact() {
 #[test]
 fn local_anticipated_before_the_assert() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2209,7 +2209,7 @@ fn local_anticipated_before_the_assert() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(entry_id, 0), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 0), x),
@@ -2233,7 +2233,7 @@ fn local_anticipated_before_the_assert() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
 }
 
@@ -2244,10 +2244,10 @@ fn local_anticipated_before_the_assert() {
 #[test]
 fn local_anticipated_needs_no_stability_gate() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c9 = ssa.add_const(Constant::Int(32, 9));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c9 = ssa.add_const(Constant::int(32, 9));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (w, y, lt) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2286,7 +2286,7 @@ fn local_anticipated_needs_no_stability_gate() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(looping, 0), w)
             .as_deref(),
-        Some(&Constant::Int(32, 9))
+        Some(&Constant::int(32, 9))
     );
     // Cross-block, `w` is withheld (both gates fail: it is loop-carried, hence unstable, and out
     // of scope at `entry`) — `entry` gets nothing even though the loop block post-dominates it.
@@ -2304,7 +2304,7 @@ fn local_anticipated_needs_no_stability_gate() {
 #[test]
 fn anticipated_equalities_and_leaders() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (a, b, m) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2372,7 +2372,7 @@ fn anticipated_equalities_and_leaders() {
 #[test]
 fn anticipated_leader_before_same_block_assert() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (a, b, m) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2426,9 +2426,9 @@ fn anticipated_leader_before_same_block_assert() {
 #[test]
 fn anticipated_leader_before_assert_in_cyclic_block() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (a, w, y, lt) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2505,8 +2505,8 @@ fn anticipated_leader_before_assert_in_cyclic_block() {
 #[test]
 fn anticipated_leader_threshold_for_block_defined_leader() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c2 = ssa.add_const(Constant::Int(32, 2));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c2 = ssa.add_const(Constant::int(32, 2));
     let (a, b, x, y) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2571,7 +2571,7 @@ fn anticipated_leader_threshold_for_block_defined_leader() {
 #[test]
 fn anticipated_leader_merges_across_directions() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     // Allocated in order ⇒ x.0 < y.0 < z.0; all entry params, so leaders are by id.
     let (x, y, z, m) = (
         ssa.fresh_value(),
@@ -2655,7 +2655,7 @@ fn anticipated_leader_at_establishing_assert_is_gate3_guarded() {
 #[test]
 fn anticipated_leader_cross_only_block_falls_back() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (a, b, m) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2697,10 +2697,10 @@ fn anticipated_leader_cross_only_block_falls_back() {
 #[test]
 fn anticipated_admits_loop_invariant_pure_chain() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (n, i, t, i2, lt) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2759,7 +2759,7 @@ fn anticipated_admits_loop_invariant_pure_chain() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(looping, 1), t)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // The same pure op over the loop-carried `i` stays out — one unstable operand poisons it —
     // and the loop must not collapse around a final-iteration-only fact.
@@ -2783,10 +2783,10 @@ fn anticipated_rejects_unconstrained_call_result_in_loop() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let helper = ssa.add_function("helper".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (p, n, i, r, i2, lt) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2856,9 +2856,9 @@ fn anticipated_rejects_unconstrained_call_result_in_loop() {
 #[test]
 fn anticipated_admits_accumulator_at_post_loop_block() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (v, lt, v1) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2901,7 +2901,7 @@ fn anticipated_admits_accumulator_at_post_loop_block() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(after, 0), v)
             .as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
     // Inside the loop both invariance and finality fail — `header`/`body` re-reach the
     // definition — so mid-loop iterations keep their genuine bindings.
@@ -2921,9 +2921,9 @@ fn anticipated_admits_accumulator_at_post_loop_block() {
 #[test]
 fn anticipated_admits_first_loop_value_inside_second_loop() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (v, lt, v1, lt2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2977,7 +2977,7 @@ fn anticipated_admits_first_loop_value_inside_second_loop() {
     assert_eq!(
         cc.anticipated_const(fid, ProgramPoint::new(second, 0), v)
             .as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
     // Still rejected inside the defining loop.
     assert_eq!(
@@ -2996,9 +2996,9 @@ fn anticipated_admits_first_loop_value_inside_second_loop() {
 #[test]
 fn anticipated_rejects_inner_loop_value_at_outer_block() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (w, lt_i, w2, lt_o) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3075,10 +3075,10 @@ fn anticipated_admits_det_call_via_congruence_tier() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let helper = ssa.add_function("helper".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (p, q, n, w, i, r, i2, lt) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3154,7 +3154,7 @@ fn anticipated_admits_det_call_via_congruence_tier() {
         assert_eq!(
             cc.anticipated_const(main_id, ProgramPoint::new(looping, 1), r)
                 .as_deref(),
-            Some(&Constant::Int(32, 5))
+            Some(&Constant::int(32, 5))
         );
         // Scope still bounds it: `r` is not defined at `entry`.
         let entry_id = ssa.get_unique_entrypoint().get_entry_id();
@@ -3181,8 +3181,8 @@ fn anticipated_admits_det_call_directly_in_loop() {
         ssa.fresh_value(),
         ssa.fresh_value(),
     );
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
 
     // `g(a) = a + 1`: deterministic but _not_ an identity, and called exactly once, so the
     // symbolic cross-call graft yields no congruent duplicate for `r` — admission is the det-call
@@ -3237,7 +3237,7 @@ fn anticipated_admits_det_call_directly_in_loop() {
     assert_eq!(
         cc.anticipated_const(main_id, ProgramPoint::new(header, 1), r)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
 }
 
@@ -3249,10 +3249,10 @@ fn anticipated_rejects_det_call_over_loop_variant_arg() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let helper = ssa.add_function("helper".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (p, q, n, i, r, i2, lt) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3331,9 +3331,9 @@ fn anticipated_det_call_multi_return_per_index_bits() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let helper = ssa.add_function("helper".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c7 = ssa.add_const(Constant::Int(32, 7));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c7 = ssa.add_const(Constant::int(32, 7));
     let (p, q, wit, cond, n, r0, r1) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3402,7 +3402,7 @@ fn anticipated_det_call_multi_return_per_index_bits() {
     assert_eq!(
         cc.anticipated_const(main_id, ProgramPoint::new(header, 1), r0)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // Return 1 is fresh advice each iteration: withheld.
     assert_eq!(
@@ -3419,7 +3419,7 @@ fn anticipated_det_call_multi_return_per_index_bits() {
 fn anticipated_admits_entry_param_in_cyclic_entry_block() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (p, w) = (ssa.fresh_value(), ssa.fresh_value());
 
     let entry_id = {
@@ -3447,7 +3447,7 @@ fn anticipated_admits_entry_param_in_cyclic_entry_block() {
     assert_eq!(
         cc.anticipated_const(main_id, ProgramPoint::new(entry_id, 0), w)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
 }
 
@@ -3461,10 +3461,10 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let helper = ssa.add_function("helper".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (p, q, cond, v, v2, lt, w, r) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3553,7 +3553,7 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
     assert_eq!(
         cc.anticipated_const(main_id, ProgramPoint::new(loop2, 1), r)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
 }
 
@@ -3563,9 +3563,9 @@ fn anticipated_admits_det_call_via_congruence_over_unstable_arg() {
 #[test]
 fn anticipated_eq_pair_mixed_gates() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (n, acc, lt, acc2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3634,7 +3634,7 @@ fn anticipated_eq_pair_mixed_gates() {
 #[test]
 fn local_assert_reaches_terminator_use() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (x, doubled) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -3669,12 +3669,12 @@ fn local_assert_reaches_terminator_use() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, term_index), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // ... but not at the assert's own index.
     assert_eq!(
@@ -3687,8 +3687,8 @@ fn local_assert_reaches_terminator_use() {
 #[test]
 fn multiple_local_asserts_each_recovered_after_its_index() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c6 = ssa.add_const(Constant::Int(32, 6));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c6 = ssa.add_const(Constant::int(32, 6));
     let (x, y) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -3715,7 +3715,7 @@ fn multiple_local_asserts_each_recovered_after_its_index() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), y),
@@ -3725,12 +3725,12 @@ fn multiple_local_asserts_each_recovered_after_its_index() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), y)
             .as_deref(),
-        Some(&Constant::Int(32, 6))
+        Some(&Constant::int(32, 6))
     );
 }
 
@@ -3740,8 +3740,8 @@ fn multiple_local_asserts_each_recovered_after_its_index() {
 #[test]
 fn contradictory_local_asserts_first_writer_wins() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c7 = ssa.add_const(Constant::Int(32, 7));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c7 = ssa.add_const(Constant::int(32, 7));
     let x = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -3772,13 +3772,13 @@ fn contradictory_local_asserts_first_writer_wins() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 1), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // After both, first-writer-wins keeps the earliest establisher.
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), x)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
 }
 
@@ -3789,9 +3789,9 @@ fn contradictory_local_asserts_first_writer_wins() {
 #[test]
 fn entry_and_local_assert_facts_layer() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c6 = ssa.add_const(Constant::Int(32, 6));
-    let c7 = ssa.add_const(Constant::Int(32, 7));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c6 = ssa.add_const(Constant::int(32, 6));
+    let c7 = ssa.add_const(Constant::int(32, 7));
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -3828,19 +3828,19 @@ fn entry_and_local_assert_facts_layer() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(inner, 0), a)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(inner, 2), a)
             .as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     // The local pin on `b` is the before-the-assert gap: absent at index 0, present after index 0.
     assert_eq!(cc.asserted_const(fid, ProgramPoint::new(inner, 0), b), None);
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(inner, 1), b)
             .as_deref(),
-        Some(&Constant::Int(32, 6))
+        Some(&Constant::int(32, 6))
     );
 }
 
@@ -3849,7 +3849,7 @@ fn entry_and_local_assert_facts_layer() {
 #[test]
 fn local_assert_on_value_defined_earlier_in_block() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (p, y) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -3882,7 +3882,7 @@ fn local_assert_on_value_defined_earlier_in_block() {
     assert_eq!(
         cc.asserted_const(fid, ProgramPoint::new(entry_id, 2), y)
             .as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
 }
 
@@ -3891,8 +3891,8 @@ fn local_assert_on_value_defined_earlier_in_block() {
 #[test]
 fn local_assert_in_loop_body() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (n, i, lt, next) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -4038,7 +4038,7 @@ fn interproc_writeback_folds_congruent_comparison_return() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let g = ssa.add_function("g".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b, eq) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -4091,7 +4091,7 @@ fn interproc_writeback_folds_congruent_comparison_return() {
     // The summary return-jump is `Const(true)`, so the call result folds in the caller context.
     assert_eq!(
         cc.const_of_in(main_id, &Context::empty(), r).as_deref(),
-        Some(&Constant::Int(1, 1))
+        Some(&Constant::int(1, 1))
     );
     // The intraprocedural view (what SCS reads) never folds a call result.
     assert_eq!(cc.const_of(main_id, r), None);
@@ -4106,7 +4106,7 @@ fn interproc_writeback_folds_congruent_comparison_in_context() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let g = ssa.add_function("g".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b, eq) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -4162,7 +4162,7 @@ fn interproc_writeback_folds_congruent_comparison_in_context() {
     // The internal comparison folds within g's single context.
     assert_eq!(
         cc.const_of_in(g, &ctxs[0], eq).as_deref(),
-        Some(&Constant::Int(1, 1))
+        Some(&Constant::int(1, 1))
     );
     // Intraprocedurally (no context) the call result in main is still not folded.
     assert_eq!(cc.const_of(main_id, r), None);
@@ -4176,7 +4176,7 @@ fn interproc_writeback_terminates_under_recursion() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let g = ssa.add_function("g".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b, eq, t) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -4238,7 +4238,7 @@ fn interproc_writeback_terminates_under_recursion() {
     for ctx in &ctxs {
         assert_eq!(
             cc.const_of_in(g, ctx, eq).as_deref(),
-            Some(&Constant::Int(1, 1))
+            Some(&Constant::int(1, 1))
         );
     }
 }
@@ -4356,7 +4356,7 @@ fn witness_forward_in_prunes_context_dead_forward() {
     let main_id = ssa.get_unique_entrypoint_id();
     let g = ssa.add_function("g".to_string());
     let (p, w, r) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let w0 = ssa.fresh_value();
 
     {
@@ -4415,7 +4415,7 @@ fn conditional_queries_parity_under_empty_context() {
     let (x, a, b) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
     let (d, e) = (ssa.fresh_value(), ssa.fresh_value());
     let (eq, r) = (ssa.fresh_value(), ssa.fresh_value());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
 
     let f = ssa.get_unique_entrypoint_mut();
     let then_b = f.add_block();
@@ -4462,7 +4462,7 @@ fn conditional_queries_parity_under_empty_context() {
     // Assert-const channel.
     assert_eq!(
         cc.asserted_const(main_id, pp, x).as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.asserted_const_in(main_id, &ctx, pp, x),
@@ -4496,7 +4496,7 @@ fn anticipated_queries_parity_under_empty_context() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let (x, a, b) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
 
     let f = ssa.get_unique_entrypoint_mut();
     let mid = f.add_block();
@@ -4528,7 +4528,7 @@ fn anticipated_queries_parity_under_empty_context() {
     // Anticipated-const channel.
     assert_eq!(
         cc.anticipated_const(main_id, pp, x).as_deref(),
-        Some(&Constant::Int(32, 5))
+        Some(&Constant::int(32, 5))
     );
     assert_eq!(
         cc.anticipated_const_in(main_id, &ctx, pp, x),
@@ -4566,7 +4566,7 @@ fn known_unequal_in_gains_from_pruned_predecessor() {
         ssa.fresh_value(),
         ssa.fresh_value(),
     );
-    let c_false = ssa.add_const(Constant::Int(1, 0));
+    let c_false = ssa.add_const(Constant::int(1, 0));
     let (d0, e0) = (ssa.fresh_value(), ssa.fresh_value());
 
     let join = {
@@ -4629,8 +4629,8 @@ fn known_unequal_in_gains_from_pruned_predecessor() {
 fn asserted_const_never_aggregate() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c1 = ssa.add_const(Constant::Int(32, 20));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c1 = ssa.add_const(Constant::int(32, 20));
     let (x, s) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -4672,8 +4672,8 @@ fn asserted_const_in_never_aggregate() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let main_id = ssa.get_unique_entrypoint_id();
     let g = ssa.add_function("g".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c1 = ssa.add_const(Constant::Int(32, 20));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c1 = ssa.add_const(Constant::int(32, 20));
     let (a, x) = (ssa.fresh_value(), ssa.fresh_value());
     let (s, y) = (ssa.fresh_value(), ssa.fresh_value());
 
@@ -5203,9 +5203,9 @@ fn cross_call_congruence_is_transitive() {
 }
 
 /// A callee that returns a pure transform of an array parameter (`p[0]`) is a deterministic
-/// function of its argument now that sequence ops are value-numbered, so two calls with
-/// congruent array arguments yield congruent results. Before this change the `ArrayGet` tainted
-/// the return as non-deterministic and the calls stayed distinct.
+/// function of its argument, because sequence ops are value-numbered, so two calls with congruent
+/// array arguments yield congruent results. An `ArrayGet` treated as non-deterministic would taint
+/// the return and keep the calls distinct.
 #[test]
 fn cross_call_congruence_for_array_returning_callee() {
     let mut ssa = HLSSA::with_main("main".to_string());
@@ -5213,7 +5213,7 @@ fn cross_call_congruence_for_array_returning_callee() {
     let pick = ssa.add_function("pick".to_string());
     let p = ssa.fresh_value();
     let elem = ssa.fresh_value();
-    let c0 = ssa.add_const(Constant::Int(32, 0));
+    let c0 = ssa.add_const(Constant::int(32, 0));
 
     // pick(p) = p[0] — deterministic in its array argument.
     {
@@ -5293,7 +5293,7 @@ fn cross_call_congruence_for_array_returning_callee() {
 #[test]
 fn cmp_eq_of_congruent_operands_folds_and_prunes_dead_edge() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b, eq) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5337,7 +5337,7 @@ fn cmp_eq_of_congruent_operands_folds_and_prunes_dead_edge() {
 
     assert!(cc.known_equal(fid, a, b));
     // The comparison is now an unconditional constant `true`.
-    assert_eq!(cc.const_of(fid, eq).as_deref(), Some(&Constant::Int(1, 1)));
+    assert_eq!(cc.const_of(fid, eq).as_deref(), Some(&Constant::int(1, 1)));
     // ...so the branch is decided: only the then-edge is executable.
     assert!(cc.is_executable_edge(fid, entry_id, then_b));
     assert!(!cc.is_executable_edge(fid, entry_id, else_b));
@@ -5351,9 +5351,9 @@ fn cmp_eq_of_congruent_operands_folds_and_prunes_dead_edge() {
 #[test]
 fn writeback_cascades_to_downstream_constant() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
-    let c7 = ssa.add_const(Constant::Int(32, 7));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
+    let c7 = ssa.add_const(Constant::int(32, 7));
     let (x, a, b, eq, p) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5401,7 +5401,7 @@ fn writeback_cascades_to_downstream_constant() {
     let cc = run_in_test(&ssa);
 
     assert!(!cc.is_reachable(fid, else_b));
-    assert_eq!(cc.const_of(fid, p).as_deref(), Some(&Constant::Int(32, 5)));
+    assert_eq!(cc.const_of(fid, p).as_deref(), Some(&Constant::int(32, 5)));
 }
 
 /// Guard: a comparison of values that are _not_ congruent stays unfolded and both branch targets
@@ -5475,7 +5475,7 @@ fn free_witnesses_are_not_congruent_so_comparison_not_folded() {
 #[test]
 fn writeback_is_noop_without_congruent_comparison() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -5500,7 +5500,7 @@ fn writeback_is_noop_without_congruent_comparison() {
 #[test]
 fn cmp_lt_of_congruent_operands_folds_false() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b, lt) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5535,7 +5535,7 @@ fn cmp_lt_of_congruent_operands_folds_false() {
     let cc = run_in_test(&ssa);
 
     assert!(cc.known_equal(fid, a, b));
-    assert_eq!(cc.const_of(fid, lt).as_deref(), Some(&Constant::Int(1, 0)));
+    assert_eq!(cc.const_of(fid, lt).as_deref(), Some(&Constant::int(1, 0)));
 }
 
 /// A comparison of congruent operands folds to a constant `true` even when it is _witnessed_
@@ -5579,8 +5579,8 @@ fn witnessed_comparison_of_congruent_operands_is_promoted() {
     // too. (SCS then keeps `ww` witness-typed via a cast; the analysis fact is the same.)
     assert!(cc.known_equal(fid, w, w));
     assert!(cc.known_equal(fid, n, n));
-    assert_eq!(cc.const_of(fid, ww).as_deref(), Some(&Constant::Int(1, 1)));
-    assert_eq!(cc.const_of(fid, nn).as_deref(), Some(&Constant::Int(1, 1)));
+    assert_eq!(cc.const_of(fid, ww).as_deref(), Some(&Constant::int(1, 1)));
+    assert_eq!(cc.const_of(fid, nn).as_deref(), Some(&Constant::int(1, 1)));
 }
 
 /// Combined-analysis win unreachable to either factor alone: two loop-carried parallel induction
@@ -5589,9 +5589,9 @@ fn witnessed_comparison_of_congruent_operands_is_promoted() {
 #[test]
 fn loop_carried_congruent_comparison_folds_true() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, j, lt, eq, i2, j2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5645,7 +5645,7 @@ fn loop_carried_congruent_comparison_folds_true() {
     let cc = run_in_test(&ssa);
 
     assert!(cc.known_equal(fid, i, j));
-    assert_eq!(cc.const_of(fid, eq).as_deref(), Some(&Constant::Int(1, 1)));
+    assert_eq!(cc.const_of(fid, eq).as_deref(), Some(&Constant::int(1, 1)));
 }
 
 // AGGREGATE CONSTANT FOLDING
@@ -5657,10 +5657,10 @@ fn loop_carried_congruent_comparison_folds_true() {
 #[test]
 fn const_array_get_folds_to_scalar() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c1 = ssa.add_const(Constant::Int(32, 20));
-    let c2 = ssa.add_const(Constant::Int(32, 30));
-    let idx = ssa.add_const(Constant::Int(32, 1));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c1 = ssa.add_const(Constant::int(32, 20));
+    let c2 = ssa.add_const(Constant::int(32, 30));
+    let idx = ssa.add_const(Constant::int(32, 1));
     let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
@@ -5683,12 +5683,12 @@ fn const_array_get_folds_to_scalar() {
     // The projection is a surfaced scalar constant.
     assert_eq!(
         cc.const_of(fid, got).as_deref(),
-        Some(&Constant::Int(32, 20))
+        Some(&Constant::int(32, 20))
     );
     assert!(
         cc.new_const_values(fid)
             .iter()
-            .any(|(v, c)| *v == got && **c == Constant::Int(32, 20))
+            .any(|(v, c)| *v == got && **c == Constant::int(32, 20))
     );
     // The aggregate stays internal: never surfaced as a constant.
     assert_eq!(cc.const_of(fid, seq), None);
@@ -5700,8 +5700,8 @@ fn const_array_get_folds_to_scalar() {
 #[test]
 fn const_repeated_array_get_and_slice_len() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let elem = ssa.add_const(Constant::Int(32, 7));
-    let idx = ssa.add_const(Constant::Int(32, 2));
+    let elem = ssa.add_const(Constant::int(32, 7));
+    let idx = ssa.add_const(Constant::int(32, 2));
     let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
@@ -5728,11 +5728,11 @@ fn const_repeated_array_get_and_slice_len() {
 
     assert_eq!(
         cc.const_of(fid, got).as_deref(),
-        Some(&Constant::Int(32, 7))
+        Some(&Constant::int(32, 7))
     );
     assert_eq!(
         cc.const_of(fid, len).as_deref(),
-        Some(&Constant::Int(32, 4))
+        Some(&Constant::int(32, 4))
     );
 }
 
@@ -5741,12 +5741,12 @@ fn const_repeated_array_get_and_slice_len() {
 #[test]
 fn const_array_set_then_get() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c1 = ssa.add_const(Constant::Int(32, 20));
-    let c2 = ssa.add_const(Constant::Int(32, 30));
-    let new_val = ssa.add_const(Constant::Int(32, 99));
-    let idx0 = ssa.add_const(Constant::Int(32, 0));
-    let idx1 = ssa.add_const(Constant::Int(32, 1));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c1 = ssa.add_const(Constant::int(32, 20));
+    let c2 = ssa.add_const(Constant::int(32, 30));
+    let new_val = ssa.add_const(Constant::int(32, 99));
+    let idx0 = ssa.add_const(Constant::int(32, 0));
+    let idx1 = ssa.add_const(Constant::int(32, 1));
     let (seq, seq2, at_set, at_orig) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5784,11 +5784,11 @@ fn const_array_set_then_get() {
 
     assert_eq!(
         cc.const_of(fid, at_set).as_deref(),
-        Some(&Constant::Int(32, 99))
+        Some(&Constant::int(32, 99))
     );
     assert_eq!(
         cc.const_of(fid, at_orig).as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
 }
 
@@ -5796,11 +5796,11 @@ fn const_array_set_then_get() {
 #[test]
 fn const_slice_push_front_and_back() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let mid = ssa.add_const(Constant::Int(32, 1));
-    let front = ssa.add_const(Constant::Int(32, 0));
-    let back = ssa.add_const(Constant::Int(32, 2));
-    let idx0 = ssa.add_const(Constant::Int(32, 0));
-    let idx1 = ssa.add_const(Constant::Int(32, 1));
+    let mid = ssa.add_const(Constant::int(32, 1));
+    let front = ssa.add_const(Constant::int(32, 0));
+    let back = ssa.add_const(Constant::int(32, 2));
+    let idx0 = ssa.add_const(Constant::int(32, 0));
+    let idx1 = ssa.add_const(Constant::int(32, 1));
     let (base, pushed_front, pushed_back, head, tail) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5847,11 +5847,11 @@ fn const_slice_push_front_and_back() {
 
     assert_eq!(
         cc.const_of(fid, head).as_deref(),
-        Some(&Constant::Int(32, 0))
+        Some(&Constant::int(32, 0))
     );
     assert_eq!(
         cc.const_of(fid, tail).as_deref(),
-        Some(&Constant::Int(32, 2))
+        Some(&Constant::int(32, 2))
     );
 }
 
@@ -5861,9 +5861,9 @@ fn const_slice_push_front_and_back() {
 #[test]
 fn const_slice_pop_folds_both_results() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c1 = ssa.add_const(Constant::Int(32, 20));
-    let c2 = ssa.add_const(Constant::Int(32, 30));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c1 = ssa.add_const(Constant::int(32, 20));
+    let c2 = ssa.add_const(Constant::int(32, 30));
     let (seq, rest, last, len) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5902,15 +5902,15 @@ fn const_slice_pop_folds_both_results() {
 
     assert_eq!(
         cc.const_of(fid, last).as_deref(),
-        Some(&Constant::Int(32, 30))
+        Some(&Constant::int(32, 30))
     );
     assert_eq!(
         cc.const_of(fid, len).as_deref(),
-        Some(&Constant::Int(32, 2))
+        Some(&Constant::int(32, 2))
     );
     assert_eq!(
         cc.const_of(fid, first).as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
 }
 
@@ -5919,11 +5919,11 @@ fn const_slice_pop_folds_both_results() {
 #[test]
 fn const_slice_insert_and_remove_fold() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c2 = ssa.add_const(Constant::Int(32, 30));
-    let mid = ssa.add_const(Constant::Int(32, 20));
-    let idx0 = ssa.add_const(Constant::Int(32, 0));
-    let idx1 = ssa.add_const(Constant::Int(32, 1));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c2 = ssa.add_const(Constant::int(32, 30));
+    let mid = ssa.add_const(Constant::int(32, 20));
+    let idx0 = ssa.add_const(Constant::int(32, 0));
+    let idx1 = ssa.add_const(Constant::int(32, 1));
     let (seq, grown, at_ins, glen) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -5971,19 +5971,19 @@ fn const_slice_insert_and_remove_fold() {
 
     assert_eq!(
         cc.const_of(fid, at_ins).as_deref(),
-        Some(&Constant::Int(32, 20))
+        Some(&Constant::int(32, 20))
     );
     assert_eq!(
         cc.const_of(fid, glen).as_deref(),
-        Some(&Constant::Int(32, 3))
+        Some(&Constant::int(32, 3))
     );
     assert_eq!(
         cc.const_of(fid, removed).as_deref(),
-        Some(&Constant::Int(32, 10))
+        Some(&Constant::int(32, 10))
     );
     assert_eq!(
         cc.const_of(fid, slen).as_deref(),
-        Some(&Constant::Int(32, 2))
+        Some(&Constant::int(32, 2))
     );
 }
 
@@ -5993,9 +5993,9 @@ fn const_mk_seq_of_blob_folds() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let blob = ssa.add_const(Constant::Blob(Blob::new(
         Type::int(32),
-        vec![Constant::Int(32, 100), Constant::Int(32, 200)],
+        vec![Constant::int(32, 100), Constant::int(32, 200)],
     )));
-    let idx = ssa.add_const(Constant::Int(32, 1));
+    let idx = ssa.add_const(Constant::int(32, 1));
     let (seq, got) = (ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
@@ -6016,7 +6016,7 @@ fn const_mk_seq_of_blob_folds() {
 
     assert_eq!(
         cc.const_of(fid, got).as_deref(),
-        Some(&Constant::Int(32, 200))
+        Some(&Constant::int(32, 200))
     );
     // The aggregate stays internal.
     assert_eq!(cc.const_of(fid, seq), None);
@@ -6027,10 +6027,10 @@ fn const_mk_seq_of_blob_folds() {
 #[test]
 fn aggregate_folding_negative_cases() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c1 = ssa.add_const(Constant::Int(32, 20));
-    let idx0 = ssa.add_const(Constant::Int(32, 0));
-    let idx_oob = ssa.add_const(Constant::Int(32, 5));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c1 = ssa.add_const(Constant::int(32, 20));
+    let idx0 = ssa.add_const(Constant::int(32, 0));
+    let idx_oob = ssa.add_const(Constant::int(32, 5));
     let p = ssa.fresh_value();
     let (seq, g_oob, seq_nc, g_nc, big, g_big) = (
         ssa.fresh_value(),
@@ -6098,10 +6098,10 @@ fn aggregate_folding_negative_cases() {
 #[test]
 fn aggregate_folding_refuses_oob_set_and_over_cap_constructors() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let c1 = ssa.add_const(Constant::Int(32, 20));
-    let idx0 = ssa.add_const(Constant::Int(32, 0));
-    let idx_oob = ssa.add_const(Constant::Int(32, 5));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let c1 = ssa.add_const(Constant::int(32, 20));
+    let idx0 = ssa.add_const(Constant::int(32, 0));
+    let idx_oob = ssa.add_const(Constant::int(32, 5));
     let over_cap = (1usize << 12) + 1; // AGGREGATE_FOLD_CAP + 1
 
     let (base, set_oob, at_set_oob) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
@@ -6177,8 +6177,8 @@ fn aggregate_folding_refuses_oob_set_and_over_cap_constructors() {
 #[test]
 fn slice_pop_insert_remove_refuse_oob() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 10));
-    let idx_oob = ssa.add_const(Constant::Int(32, 5));
+    let c0 = ssa.add_const(Constant::int(32, 10));
+    let idx_oob = ssa.add_const(Constant::int(32, 5));
     let (empty, rest, elem) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
     let (frest, felem) = (ssa.fresh_value(), ssa.fresh_value());
     let (one, inserted) = (ssa.fresh_value(), ssa.fresh_value());

--- a/compiler/src/compiler/analysis/instrumenter.rs
+++ b/compiler/src/compiler/analysis/instrumenter.rs
@@ -10,7 +10,8 @@ use std::{cell::RefCell, rc::Rc};
 use ark_ff::{BigInt, BigInteger};
 use itertools::Itertools;
 use mavros_artifacts::FieldConfig;
-use mavros_int_semantics::{self as semantics};
+use mavros_int_semantics::{self as semantics, CmpOp, IntBits};
+use num_bigint::BigUint;
 use tracing::{debug, instrument};
 
 use crate::{
@@ -30,10 +31,7 @@ use crate::{
                 SliceOpDir, Type, TypeExpr,
             },
         },
-        util::{
-            bit_mask, decode_signed, ice_non_elided_tuple, sign_extend_bits, spread_bits,
-            unspread_bits,
-        },
+        util::{host_word, ice_non_elided_tuple, spread_bits, unspread_bits},
     },
 };
 
@@ -57,7 +55,7 @@ impl ScalarKind {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ValueSignature {
-    Int { bits_size: usize, value: u128 },
+    Int(IntBits),
     Field(Field),
     Array(Vec<ValueSignature>),
     Blob(Vec<ValueSignature>),
@@ -70,7 +68,7 @@ pub enum ValueSignature {
 impl ValueSignature {
     pub fn to_value(&self) -> Value {
         match self {
-            ValueSignature::Int { bits_size, value } => Value::Int(*bits_size, *value),
+            ValueSignature::Int(pattern) => Value::Int(pattern.clone()),
             ValueSignature::Field(field) => Value::Field(*field),
             ValueSignature::Array(vals) => {
                 Value::array(vals.iter().map(|v| v.to_value()).collect())
@@ -85,7 +83,11 @@ impl ValueSignature {
 
     pub fn pretty_print(&self, full: bool) -> String {
         match self {
-            ValueSignature::Int { value, .. } => format!("{value}"),
+            // The **value**, in decimal, and not the pattern's `Debug` form: this string becomes
+            // part of a specialized function's name, so it is user-visible and it is embedded in
+            // every artifact that carries a name. A `BigUint` prints the same decimal at any
+            // width, where a host word would stop at 128 bits.
+            ValueSignature::Int(pattern) => format!("{}", BigUint::from(pattern)),
             ValueSignature::Field(f) => format!("{}", f),
             ValueSignature::Array(items) => {
                 if full {
@@ -114,35 +116,62 @@ impl ValueSignature {
 #[derive(Debug, Clone)]
 // FIELD-ASSUMPTION: L4-eval
 pub enum Value {
-    /// `bits` raw two's-complement bits. Which reading applies is decided by the opcode the
-    /// interpreter is executing, never by the value — see [`Value::binary_arith_op`].
-    Int(usize, u128),
+    /// A raw two's-complement pattern. Which reading applies is decided by the opcode instead of
+    /// the value.
+    Int(IntBits),
+
+    /// A field element.
     Field(Field),
+
+    /// An aggregate whose elements are each known — an `Array`, and also a `Slice` whose length
+    /// is.
     Array(Rc<Vec<Value>>),
+
+    /// A `Blob`: HLSSA's compile-time-only sequence for long constant data.
     Blob(Vec<Value>),
+
+    /// What a `Ref` points at, shared with every other value that aliases it.
     Pointer(Rc<RefCell<Value>>),
+
+    /// A scalar whose value is not known, carrying the _kind_ it would have had.
     Unknown(ScalarKind),
+
+    /// A slice whose **length** is not known, which is why it is not a [`Value::Unknown`].
     UnknownSlice,
+
+    /// A value the circuit carries as a witness, wrapping whatever it is a witness _of_.
     WitnessOf(Box<Value>),
 }
 
+/// A constant used as a machine index, refusing rather than truncating.
+///
+/// An `as usize` would let a value above `usize::MAX` land back inside a bounds check it should
+/// have failed. Where an out-of-range index is tolerable this is not the right function — see
+/// `array_get`, which answers `Unknown`.
+fn const_index(pattern: &IntBits) -> usize {
+    usize::try_from(pattern).expect("ICE: a constant index is wider than the machine")
+}
+
 impl Value {
+    /// A `bits`-wide value carrying `value`, discarding any bits at or above `bits`.
+    ///
+    /// The convenience constructor for the many sites here that hold a host word and a width,
+    /// exactly as `Constant::int` is for the IR's own constants.
+    fn int(bits: usize, value: u128) -> Self {
+        Value::Int(IntBits::from_u128(bits, value))
+    }
+
     fn array(values: Vec<Value>) -> Self {
         Value::Array(Rc::new(values))
     }
 
     fn as_field_const(&self, field: FieldConfig) -> Option<Field> {
         match self {
-            Value::Int(_, v) => Some(field.constant(*v)),
+            Value::Int(v) => Some(field.constant(host_word(v))),
             Value::Field(f) => Some(*f),
             Value::WitnessOf(inner) => inner.as_field_const(field),
             _ => None,
         }
-    }
-
-    /// Interpret a u128 two's-complement value as signed i128 for `bits` width.
-    fn to_signed(val: u128, bits: usize) -> i128 {
-        decode_signed(bits, val & bit_mask(bits))
     }
 
     fn unwrap_witness(&self) -> &Value {
@@ -184,16 +213,21 @@ impl Value {
     /// magnitudes and `Eq` needs no reading at all.
     fn cmp_op(&self, b: &Value, kind: CmpKind, bits: Option<usize>) -> Value {
         match (self, b) {
-            (Value::Int(_, a), Value::Int(_, b)) => {
+            (Value::Int(a), Value::Int(b)) => {
                 let result = match kind {
-                    CmpKind::Eq => a == b,
-                    CmpKind::ULt => a < b,
+                    CmpKind::Eq | CmpKind::ULt if a.bits() == b.bits() => {
+                        a.compare(CmpOp::from(kind), b)
+                    }
+                    CmpKind::Eq => BigUint::from(a) == BigUint::from(b),
+                    CmpKind::ULt => BigUint::from(a) < BigUint::from(b),
                     CmpKind::SLt => {
                         let bits = bits.expect("ICE: signed comparison without an operand width");
-                        Self::to_signed(*a, bits) < Self::to_signed(*b, bits)
+                        // Read at the width the _operation_ names, which is what the mask this
+                        // replaces did, and what keeps the two operands one width apiece.
+                        a.cast(bits).to_signed() < b.cast(bits).to_signed()
                     }
                 };
-                Value::Int(1, result as u128)
+                Value::int(1, result as u128)
             }
             // A field element has no two's complement reading, so an `SLt` over one never reaches
             // here as the executor rejects it before the call. `ULt` and `Eq` compare the elements
@@ -203,7 +237,7 @@ impl Value {
                     CmpKind::Eq => a == b,
                     CmpKind::ULt | CmpKind::SLt => a < b,
                 };
-                Value::Int(1, result as u128)
+                Value::int(1, result as u128)
             }
             (Value::WitnessOf(_), _) | (_, Value::WitnessOf(_)) => Value::WitnessOf(Box::new(
                 self.unwrap_witness().cmp_op(b.unwrap_witness(), kind, bits),
@@ -243,7 +277,9 @@ impl Value {
         // dispatch below rather than inside its integer and field arms.
         if group == ArithGroup::Mul {
             match (self, b) {
-                (Value::Int(s, 0), _) | (_, Value::Int(s, 0)) => return Value::Int(*s, 0),
+                (Value::Int(z), _) | (_, Value::Int(z)) if z.is_zero() => {
+                    return Value::Int(z.clone());
+                }
                 (Value::Field(f), _) if *f == instrumenter.field().zero() => {
                     return Value::Field(instrumenter.field().zero());
                 }
@@ -259,17 +295,11 @@ impl Value {
             // the type analysis widens a result to the wider operand; a shift is the case where
             // they legitimately differ, and an amount's own width is the only thing that says what
             // its pattern means.
-            (Value::Int(bits, lhs), Value::Int(rhs_bits, rhs)) => Value::Int(
-                *bits,
-                semantics::residue(
-                    group.into(),
-                    binary_arith_op_kind.sign(),
-                    *bits,
-                    *lhs,
-                    *rhs_bits,
-                    *rhs,
-                )
-                .unwrap_or(0),
+            (Value::Int(lhs), Value::Int(rhs)) => Value::Int(
+                semantics::residue((*binary_arith_op_kind).into(), lhs, rhs)
+                    // The model leaves the two division cases unspecified; this evaluator is an
+                    // estimator rather than a backend, so it answers zero as the VM does.
+                    .unwrap_or_else(|| IntBits::zero(lhs.bits())),
             ),
 
             (Value::Field(x), Value::Field(y)) => match group {
@@ -327,7 +357,7 @@ impl Value {
                 inner.forget_concrete();
             }
             Value::Unknown(_) | Value::UnknownSlice => {}
-            Value::Int(_, _) | Value::Field(_) => {}
+            Value::Int(_) | Value::Field(_) => {}
             Value::Array(vals) => {
                 for val in Rc::make_mut(vals).iter_mut() {
                     val.blind();
@@ -346,7 +376,7 @@ impl Value {
 
     fn forget_concrete(&mut self) {
         match self {
-            Value::Int(s, _) => *self = Value::Unknown(ScalarKind::Int(*s)),
+            Value::Int(v) => *self = Value::Unknown(ScalarKind::Int(v.bits())),
             Value::Field(_) => *self = Value::Unknown(ScalarKind::Field),
             Value::Unknown(_) | Value::UnknownSlice => {}
             Value::WitnessOf(inner) => {
@@ -375,10 +405,7 @@ impl Value {
             Value::WitnessOf(inner) => {
                 ValueSignature::WitnessOf(Box::new(inner.make_unspecialized_sig()))
             }
-            Value::Int(s, v) => ValueSignature::Int {
-                bits_size: *s,
-                value: *v,
-            },
+            Value::Int(v) => ValueSignature::Int(v.clone()),
             Value::Field(f) => ValueSignature::Field(*f),
             Value::Array(vals) => {
                 ValueSignature::Array(vals.iter().map(|v| v.make_unspecialized_sig()).collect())
@@ -412,14 +439,14 @@ impl Value {
         // to its (constant-false) bounds assert plus an `ArrayGet` at index 0 — and rejecting
         // such a program is witgen's job, not the cost estimator's. Answering `Unknown` just
         // declines to specialize through the read.
-        let at = |i: &u128| match values.get(*i as usize) {
+        let at = |i: &IntBits| match usize::try_from(i).ok().and_then(|i| values.get(i)) {
             Some(value) => value.clone(),
             None => Value::unknown_from_type(tp),
         };
         match index {
-            Value::Int(_, i) => at(i),
+            Value::Int(i) => at(i),
             Value::WitnessOf(inner) => match inner.as_ref() {
-                Value::Int(_, i) => at(i),
+                Value::Int(i) => at(i),
                 _ => Value::unknown_from_type(tp),
             },
             Value::Unknown(_) => Value::unknown_from_type(tp),
@@ -437,15 +464,15 @@ impl Value {
         _instrumenter: &mut dyn OpInstrumenter,
     ) -> Value {
         match (self, index, value) {
-            (Value::Array(vals), Value::Int(_, index), value) => {
+            (Value::Array(vals), Value::Int(index), value) => {
                 let mut new_vals = vals.as_ref().clone();
-                new_vals[*index as usize] = value.clone();
+                new_vals[const_index(index)] = value.clone();
                 Value::array(new_vals)
             }
             (Value::Array(vals), Value::WitnessOf(inner), value) => match inner.as_ref() {
-                Value::Int(_, index) => {
+                Value::Int(index) => {
                     let mut new_vals = vals.as_ref().clone();
-                    new_vals[*index as usize] = value.clone();
+                    new_vals[const_index(index)] = value.clone();
                     Value::array(new_vals)
                 }
                 _ => {
@@ -477,7 +504,8 @@ impl Value {
             Value::WitnessOf(inner) => {
                 Value::WitnessOf(Box::new(inner.bit_range_op(offset, width, instrumenter)))
             }
-            Value::Int(bits, v) => Value::Int(*bits, (v >> offset) & bit_mask(width)),
+            Value::Int(v) if width == 0 => Value::Int(IntBits::zero(v.bits())),
+            Value::Int(v) => Value::Int(v.bit_range(offset, width).cast(v.bits())),
             Value::Field(f) => {
                 let bits = f
                     .into_bigint()
@@ -495,26 +523,33 @@ impl Value {
         }
     }
 
-    fn sext_op(&self, from: usize, to: usize, _instrumenter: &mut dyn OpInstrumenter) -> Value {
+    /// The instruction's `from_bits` is not a parameter: the value carries the width it is being
+    /// extended from, and `analysis::types` is where the two are held to each other.
+    fn sext_op(&self, to: usize, _instrumenter: &mut dyn OpInstrumenter) -> Value {
         match self {
-            Value::Unknown(kind) => Value::Unknown(*kind),
-            Value::WitnessOf(inner) => {
-                Value::WitnessOf(Box::new(inner.sext_op(from, to, _instrumenter)))
-            }
-            Value::Int(_, v) => Value::Int(to, sign_extend_bits(*v, from, to)),
+            // An unknown widens like a known one. The kind is the only width an unknown carries,
+            // so leaving it at the source's would describe the result at the wrong width in two
+            // places that read it: `ValueSignature::Unknown` keys a specialization on it, and
+            // `spread_op` bounds itself by it -- a stale `int64` would pass a `<= 64` check that
+            // the `int128` this actually produces must fail.
+            Value::Unknown(ScalarKind::Int(_)) => Value::Unknown(ScalarKind::Int(to)),
+            Value::WitnessOf(inner) => Value::WitnessOf(Box::new(inner.sext_op(to, _instrumenter))),
+            Value::Int(v) => Value::Int(v.sign_extend(to)),
+            // `Unknown(Field)` lands here with `Value::Field`: a field has no sign bit to fill, and
+            // `analysis::types` rejects an `SExt` on one before this is ever reached.
             _ => panic!("Cannot sext {:?}", self),
         }
     }
 
     fn spread_op(&self) -> Value {
         match self {
-            Value::Int(bits, v) => {
+            Value::Int(v) => {
+                let bits = v.bits();
                 assert!(
-                    *bits <= 64,
-                    "Spread only supports integer widths up to 64 bits, got int{}",
-                    bits
+                    bits <= 64,
+                    "Spread only supports integer widths up to 64 bits, got int{bits}"
                 );
-                Value::Int(bits * 2, spread_bits(*v, *bits))
+                Value::int(bits * 2, spread_bits(host_word(v), bits))
             }
             Value::Field(_) => panic!("Spread of field values is unsupported"),
             Value::WitnessOf(inner) => Value::WitnessOf(Box::new(inner.spread_op())),
@@ -533,17 +568,17 @@ impl Value {
 
     fn unspread_op(&self) -> (Value, Value) {
         match self {
-            Value::Int(bits, v) => {
+            Value::Int(v) => {
+                let bits = v.bits();
                 assert!(
-                    *bits <= MAX_SUPPORTED_UNSIGNED_BITS && bits % 2 == 0,
-                    "Unspread expects an even integer width up to {MAX_SUPPORTED_UNSIGNED_BITS} bits, got int{}",
-                    bits
+                    bits <= MAX_SUPPORTED_UNSIGNED_BITS && bits % 2 == 0,
+                    "Unspread expects an even integer width up to {MAX_SUPPORTED_UNSIGNED_BITS} bits, got int{bits}"
                 );
-                let (odd_val, even_val) = unspread_bits(*v, *bits);
+                let (odd_val, even_val) = unspread_bits(host_word(v), bits);
                 let half_bits = bits / 2;
                 (
-                    Value::Int(half_bits, odd_val),
-                    Value::Int(half_bits, even_val),
+                    Value::int(half_bits, odd_val),
+                    Value::int(half_bits, even_val),
                 )
             }
             Value::Field(_) => panic!("Unspread of field values is unsupported"),
@@ -596,25 +631,16 @@ impl Value {
             (Value::WitnessOf(inner), target) => {
                 Value::WitnessOf(Box::new(inner.cast_op(target, instrumenter)))
             }
-            (Value::Int(_, v), CastTarget::Int(s2)) => Value::Int(*s2, *v & bit_mask(*s2)),
-            // Raw bits, and _only_ raw bits. There used to be a second arm here, reached whenever
-            // the operand happened to be tagged `I`, that decoded to two's complement and then
-            // `as u64` — which disagreed with every other implementation of this cast
-            // (`lattice::eval_cast` takes the raw payload, `hlssa_to_r1cs::of_int` builds
-            // `Fr::from(raw)`, and the LLVM path zero-extends) and mangled the value on top of it,
-            // since `as u64` on a negative `i128` is not a field element's worth of anything. The
-            // cost interpreter has to agree with the circuit it is estimating, so the surviving
-            // arm is the one the backends implement.
-            (Value::Int(_, v), CastTarget::Field) => {
-                Value::Field(instrumenter.field().constant(*v))
+            (Value::Int(_), CastTarget::Int(0)) => {
+                panic!("ICE: a cast to int0 describes a value with no bits")
+            }
+            (Value::Int(v), CastTarget::Int(s2)) => Value::Int(v.cast(*s2)),
+            (Value::Int(v), CastTarget::Field) => {
+                Value::Field(instrumenter.field().constant(host_word(v)))
             }
             (Value::Field(f), CastTarget::Field) => Value::Field(*f),
             (Value::Field(f), CastTarget::Int(s)) => {
-                let bigint = f.into_bigint();
-                Value::Int(
-                    *s,
-                    (bigint.0[0] as u128 | ((bigint.0[1] as u128) << 64)) & bit_mask(*s),
-                )
+                Value::Int(IntBits::from_field_limbs(&f.into_bigint().0, *s))
             }
             (_, CastTarget::Nop | CastTarget::ArrayToSlice) => self.clone(),
             _ => panic!("Cannot cast {:?} to {:?}", self, cast_target),
@@ -667,18 +693,11 @@ impl Value {
             }
             // Decomposition is a property of the bit pattern, so a signed value decomposes
             // exactly as its unsigned twin does. The bits themselves are always `u1`.
-            Value::Int(_, v) => {
+            Value::Int(v) => {
+                // A bit at or above the width is absent rather than zero, and reads as `false`
+                // either way, so a decomposition wider than the value zero-fills.
                 let mut r = (0..size)
-                    .map(|i| {
-                        Value::Int(
-                            1,
-                            if i < u128::BITS as usize {
-                                (v >> i) & 1
-                            } else {
-                                0
-                            },
-                        )
-                    })
+                    .map(|i| Value::int(1, u128::from(v.bit(i).unwrap_or(false))))
                     .collect::<Vec<_>>();
                 if *endianness == Endianness::Big {
                     r.reverse();
@@ -689,7 +708,7 @@ impl Value {
                 let bigint = f.into_bigint();
                 let raw_bits = bigint.to_bits_le();
                 let mut bits = (0..size)
-                    .map(|i| Value::Int(1, raw_bits.get(i).copied().unwrap_or(false) as u128))
+                    .map(|i| Value::int(1, raw_bits.get(i).copied().unwrap_or(false) as u128))
                     .collect::<Vec<_>>();
                 if *endianness == Endianness::Big {
                     bits.reverse();
@@ -723,7 +742,7 @@ impl Value {
             Value::Unknown(_) => Value::array(vec![Value::Unknown(ScalarKind::Int(8)); size]),
             Value::Field(f) => {
                 let radix_val = match radix {
-                    Radix::Dyn(Value::Int(_, r)) => *r,
+                    Radix::Dyn(Value::Int(r)) => host_word(r),
                     Radix::Bytes => 256,
                     _ => panic!("Cannot convert {:?} to radix {:?}", self, radix),
                 };
@@ -734,7 +753,7 @@ impl Value {
                         let limb = val.0[0] as u128;
                         limb % radix_val
                     };
-                    digits.push(Value::Int(8, digit));
+                    digits.push(Value::int(8, digit));
                     // Divide val by radix_val
                     let mut carry: u128 = 0;
                     for i in (0..val.0.len()).rev() {
@@ -753,7 +772,7 @@ impl Value {
         match self {
             Value::Unknown(kind) => Value::Unknown(*kind),
             Value::WitnessOf(inner) => Value::WitnessOf(Box::new(inner.not_op(_instrumenter))),
-            Value::Int(s, v) => Value::Int(*s, !v & bit_mask(*s)),
+            Value::Int(v) => Value::Int(v.complement()),
             _ => panic!("Cannot perform not operation on {:?}", self),
         }
     }
@@ -784,11 +803,11 @@ impl Value {
         _instrumenter: &mut dyn OpInstrumenter,
     ) -> Value {
         match self {
-            Value::Int(_, 0) => if_false.clone(),
-            Value::Int(_, _) => if_true.clone(),
+            Value::Int(v) if v.is_zero() => if_false.clone(),
+            Value::Int(_) => if_true.clone(),
             Value::WitnessOf(inner) => match inner.as_ref() {
-                Value::Int(_, 0) => if_false.clone(),
-                Value::Int(_, _) => if_true.clone(),
+                Value::Int(v) if v.is_zero() => if_false.clone(),
+                Value::Int(_) => if_true.clone(),
                 _ => {
                     let mut result = if_true.clone();
                     result.forget_concrete();
@@ -896,9 +915,13 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
         }
     }
 
+    /// `from` goes unread: this evaluator's integers are [`IntBits`], which carry the width they
+    /// are extended from. It stays on the trait because it is not redundant everywhere — the R1CS
+    /// evaluator's values are field elements with no width of their own, and CSE's interner needs
+    /// it to key the node — so this is a property of the value domain rather than of the opcode.
     fn sext(
         &self,
-        from: usize,
+        _from: usize,
         to: usize,
         _tp: &Type,
         instrumenter: &mut CostAnalysis,
@@ -906,10 +929,8 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
         SpecSplitValue {
             unspecialized: self
                 .unspecialized
-                .sext_op(from, to, instrumenter.get_unspecialized()),
-            specialized: self
-                .specialized
-                .sext_op(from, to, instrumenter.get_specialized()),
+                .sext_op(to, instrumenter.get_unspecialized()),
+            specialized: self.specialized.sext_op(to, instrumenter.get_specialized()),
         }
     }
 
@@ -1123,14 +1144,14 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
 
     fn expect_constant_bool(&self, _ctx: &mut CostAnalysis) -> bool {
         let specialized = match &self.specialized {
-            Value::Int(1, v) => *v != 0,
+            Value::Int(v) if v.bits() == 1 => !v.is_zero(),
             _ => panic!(
                 "Expected constant bool, got specialized={:?}",
                 self.specialized
             ),
         };
         let unspecialized = match &self.unspecialized {
-            Value::Int(1, v) => *v != 0,
+            Value::Int(v) if v.bits() == 1 => !v.is_zero(),
             _ => panic!(
                 "Expected constant bool, got unspecialized={:?}",
                 self.unspecialized
@@ -1148,10 +1169,10 @@ impl symbolic_executor::Value<CostAnalysis> for SpecSplitValue {
         specialized
     }
 
-    fn of_int(s: usize, v: u128, _ctx: &mut CostAnalysis) -> Self {
+    fn of_int(v: &IntBits, _ctx: &mut CostAnalysis) -> Self {
         Self {
-            unspecialized: Value::Int(s, v),
-            specialized: Value::Int(s, v),
+            unspecialized: Value::Int(v.clone()),
+            specialized: Value::Int(v.clone()),
         }
     }
 
@@ -1781,12 +1802,12 @@ impl symbolic_executor::Context<SpecSplitValue> for CostAnalysis {
 
     fn slice_len(&mut self, slice: &SpecSplitValue) -> SpecSplitValue {
         let unspec = match &slice.unspecialized {
-            Value::Array(values) => Value::Int(32, values.len() as u128),
+            Value::Array(values) => Value::int(32, values.len() as u128),
             Value::UnknownSlice => Value::Unknown(ScalarKind::Int(32)),
             _ => panic!("Cannot get length of {:?}", slice.unspecialized),
         };
         let spec = match &slice.specialized {
-            Value::Array(values) => Value::Int(32, values.len() as u128),
+            Value::Array(values) => Value::int(32, values.len() as u128),
             Value::UnknownSlice => Value::Unknown(ScalarKind::Int(32)),
             _ => panic!("Cannot get length of {:?}", slice.specialized),
         };
@@ -2199,7 +2220,10 @@ impl Analysis for Summary {
 
 #[cfg(test)]
 mod tests {
-    use super::{BinaryArithOpKind, CmpKind, CostEstimator, DummyInstrumenter, ScalarKind, Value};
+    use super::{
+        BinaryArithOpKind, CmpKind, CostEstimator, DummyInstrumenter, ScalarKind, Value,
+        ValueSignature,
+    };
     use crate::compiler::{
         analysis::{flow_analysis::FlowAnalysis, types::Types},
         pass_manager::{AnalysisStore, Pass},
@@ -2210,7 +2234,151 @@ mod tests {
         },
     };
     use mavros_artifacts::FieldConfig;
-    use mavros_int_semantics::{IntOp, Sign, corners, residue};
+    use mavros_int_semantics::{IntBits, IntOp, corners, residue};
+
+    use crate::compiler::util::host_word;
+
+    /// Whether a value is the one-bit pattern `expected`.
+    ///
+    /// `Value` has no `PartialEq`, and giving it one to serve a test would be a change to the
+    /// analysis rather than to the test, so the comparison is written where it is needed.
+    fn is_bit(v: &Value, expected: u128) -> bool {
+        matches!(v, Value::Int(p) if *p == IntBits::from_u128(1, expected))
+    }
+
+    /// A signature prints the value it carries, because that string becomes a function's name.
+    #[test]
+    fn a_signature_prints_the_value_not_the_pattern() {
+        let sig = ValueSignature::Int(IntBits::from_u128(8, 200));
+        assert_eq!(sig.pretty_print(true), "200");
+        assert_eq!(sig.pretty_print(false), "200");
+
+        // Wide enough that a host word could not carry it, so the printing cannot quietly acquire
+        // a cap along with a shorter spelling.
+        let wide = ValueSignature::Int(IntBits::all_ones(200));
+        assert_eq!(
+            wide.pretty_print(true),
+            "1606938044258990275541962092341162602522202993782792835301375"
+        );
+    }
+
+    /// A `Field -> Int` cast reads the whole canonical decomposition, not the low two limbs.
+    #[test]
+    fn a_field_to_int_cast_agrees_with_the_constant_folder() {
+        use crate::compiler::analysis::click_cooper::lattice;
+        use crate::compiler::ssa::hlssa::{CastTarget, Constant};
+
+        let field = FieldConfig::bn254();
+        let mut dummy = DummyInstrumenter { field };
+
+        for value in [0u128, 1, 0xDEAD_BEEF, (1u128 << 64) + 7, u128::MAX >> 1] {
+            let f = field.constant(value);
+            for bits in [1usize, 8, 32, 64, 65, 128] {
+                let got = Value::Field(f).cast_op(&CastTarget::Int(bits), &mut dummy);
+                let want = lattice::eval_cast(&CastTarget::Int(bits), &Constant::Field(f), field)
+                    .expect("the folder casts a field constant to any supported width");
+
+                assert!(
+                    matches!((&got, &want), (Value::Int(a), Constant::Int(b)) if a == b),
+                    "{value:#x} at {bits} bits: interpreter said {got:?}, folder said {want:?}"
+                );
+            }
+        }
+    }
+
+    /// An unknown widens too: the kind is the only width it carries.
+    ///
+    /// The width matters even with no value behind it. `ValueSignature::Unknown` keys a
+    /// specialization on the kind, and `spread_op` bounds itself by it -- so an unknown left at the
+    /// width it was extended *from* would both key on the wrong thing and pass a `<= 64` check the
+    /// width it actually has must fail.
+    #[test]
+    fn an_unknown_carries_the_width_it_was_extended_to() {
+        let mut dummy = DummyInstrumenter {
+            field: FieldConfig::bn254(),
+        };
+
+        let widened = Value::Unknown(ScalarKind::Int(8)).sext_op(16, &mut dummy);
+        assert!(
+            matches!(widened, Value::Unknown(ScalarKind::Int(16))),
+            "an unknown int8 sign-extended to 16 is an unknown int16, got {widened:?}"
+        );
+
+        // Through a witness wrapper, which is how a witness operand reaches the same arm.
+        let wrapped =
+            Value::WitnessOf(Box::new(Value::Unknown(ScalarKind::Int(8)))).sext_op(64, &mut dummy);
+        let Value::WitnessOf(inner) = &wrapped else {
+            panic!("the witness wrapper must survive, got {wrapped:?}");
+        };
+        assert!(matches!(**inner, Value::Unknown(ScalarKind::Int(64))));
+
+        // And the consequence that is not merely a wrong number: the widened value is past the
+        // bound `spread_op` enforces, so it must now be refused there rather than sailing through
+        // on the source's width.
+        let past_the_bound = Value::Unknown(ScalarKind::Int(64)).sext_op(128, &mut dummy);
+        assert!(matches!(
+            past_the_bound,
+            Value::Unknown(ScalarKind::Int(128))
+        ));
+    }
+
+    /// Sign extension fills, where a cast zero-extends.
+    #[test]
+    fn sign_extension_fills_where_a_cast_would_not() {
+        let mut dummy = DummyInstrumenter {
+            field: FieldConfig::bn254(),
+        };
+        let negative = Value::int(8, 0x80);
+        let positive = Value::int(8, 0x7F);
+
+        let widened = negative.sext_op(16, &mut dummy);
+        assert!(
+            matches!(&widened, Value::Int(p) if *p == IntBits::from_u128(16, 0xFF80)),
+            "-128i8 widens to -128i16, got {widened:?}"
+        );
+
+        let widened = positive.sext_op(16, &mut dummy);
+        assert!(
+            matches!(&widened, Value::Int(p) if *p == IntBits::from_u128(16, 0x007F)),
+            "a non-negative widens with zeros, got {widened:?}"
+        );
+    }
+
+    /// An empty window answers zero rather than panicking, and does so at the source's width.
+    #[test]
+    fn an_empty_bit_range_answers_zero_at_the_source_width() {
+        let mut dummy = DummyInstrumenter {
+            field: FieldConfig::bn254(),
+        };
+
+        // A non-zero offset is what carries a zero width past a guard written on `offset + width`.
+        for offset in [0usize, 5, 16] {
+            let empty = Value::int(16, 0xABCD).bit_range_op(offset, 0, &mut dummy);
+            assert!(
+                matches!(&empty, Value::Int(p) if *p == IntBits::zero(16)),
+                "an empty window at offset {offset} is zero at sixteen bits, got {empty:?}"
+            );
+        }
+
+        // And a one-bit window still reads a bit, so the arm above rejects the empty case only.
+        let bit = Value::int(16, 0xABCD).bit_range_op(6, 1, &mut dummy);
+        assert!(
+            matches!(&bit, Value::Int(p) if *p == IntBits::from_u128(16, 1)),
+            "bit 6 of 0xABCD is set, got {bit:?}"
+        );
+    }
+
+    /// A cast to no width is refused here, where the target width can be named.
+    #[test]
+    #[should_panic(expected = "a cast to int0 describes a value with no bits")]
+    fn a_cast_to_no_width_is_refused_by_the_estimator() {
+        use crate::compiler::ssa::hlssa::CastTarget;
+
+        let mut dummy = DummyInstrumenter {
+            field: FieldConfig::bn254(),
+        };
+        let _ = Value::int(8, 1).cast_op(&CastTarget::Int(0), &mut dummy);
+    }
 
     /// The comparison's reading comes from the opcode, so one pair of operands must compare two
     /// different ways under the two orderings.
@@ -2223,10 +2391,10 @@ mod tests {
     fn a_comparison_reads_its_operands_the_way_the_opcode_says() {
         // 0xFB in eight bits is 251 read as a magnitude and -5 read as two's complement, so the
         // two readings disagree about every comparison of it against a small positive.
-        let a = Value::Int(8, 0xFB);
-        let b = Value::Int(8, 2);
+        let a = Value::int(8, 0xFB);
+        let b = Value::int(8, 2);
 
-        let is = |v: Value, expected: u128| matches!(v, Value::Int(1, got) if got == expected);
+        let is = |v: Value, expected: u128| is_bit(&v, expected);
 
         assert!(
             is(a.cmp_op(&b, CmpKind::ULt, Some(8)), 0),
@@ -2235,11 +2403,20 @@ mod tests {
         assert!(is(a.cmp_op(&b, CmpKind::SLt, Some(8)), 1), "-5 < 2 is true");
         assert!(is(a.cmp_op(&b, CmpKind::Eq, Some(8)), 0));
         assert!(is(a.cmp_op(&a, CmpKind::Eq, Some(8)), 1));
+
+        assert!(
+            is(b.cmp_op(&a, CmpKind::ULt, Some(8)), 1),
+            "2 < 251 is true as magnitudes"
+        );
+        assert!(
+            is(b.cmp_op(&a, CmpKind::SLt, Some(8)), 0),
+            "2 < -5 is false as two's complement"
+        );
     }
 
-    /// An out-of-range shift amount **masks** to `bits - 1` rather than saturating.
+    /// An out-of-range shift amount **reduces** modulo `bits` rather than saturating.
     #[test]
-    fn an_out_of_range_shift_amount_masks_rather_than_saturating() {
+    fn an_out_of_range_shift_amount_reduces_rather_than_saturating() {
         use BinaryArithOpKind::{SShl, SShr, UShl, UShr};
 
         let mut dummy = DummyInstrumenter {
@@ -2252,35 +2429,36 @@ mod tests {
             dummy: &mut DummyInstrumenter,
         ) -> u128 {
             match a.binary_arith_op(b, &kind, dummy) {
-                Value::Int(_, v) => v,
+                Value::Int(v) => host_word(&v),
                 other => panic!("expected an integer result, got {other:?}"),
             }
         }
 
-        // An amount wider than the value, whose low three bits are `0`: `256 & 7 == 0`, so every
+        // An amount wider than the value that is a multiple of it: `256 % 8 == 0`, so every
         // direction and every reading shifts by nothing and returns the value untouched.
-        let value = Value::Int(8, 0x5A);
-        let wide = Value::Int(32, 256);
+        let value = Value::int(8, 0x5A);
+        let wide = Value::int(32, 256);
         for kind in [SShl, UShl, SShr, UShr] {
             assert_eq!(
                 shift(&value, &wide, kind, &mut dummy),
                 0x5A,
-                "{kind:?} by 256 at eight bits masks to a shift by zero"
+                "{kind:?} by 256 at eight bits reduces to a shift by zero"
             );
         }
 
         // An in-range amount is untouched by any of this, which is what keeps the assertions above
         // from passing on a shift that had simply stopped working.
-        let one = Value::Int(8, 1);
+        let one = Value::int(8, 1);
         assert_eq!(shift(&value, &one, UShl, &mut dummy), 0xB4);
         assert_eq!(shift(&value, &one, UShr, &mut dummy), 0x2D);
 
-        // A negative amount is a large magnitude, so it masks to `7` rather than saturating.
-        let negative = Value::Int(8, 0xFF);
+        // A negative amount is a large magnitude, so it reduces to `255 % 8 == 7` rather than
+        // saturating.
+        let negative = Value::int(8, 0xFF);
         assert_eq!(shift(&value, &negative, SShl, &mut dummy), 0x00);
         assert_eq!(shift(&value, &negative, UShr, &mut dummy), 0x00);
         assert_eq!(
-            shift(&Value::Int(8, 0xF0), &negative, SShr, &mut dummy),
+            shift(&Value::int(8, 0xF0), &negative, SShr, &mut dummy),
             0xFF,
             "sign-filling a negative value still saturates it at -1, by shifting seven places"
         );
@@ -2296,34 +2474,41 @@ mod tests {
             field: FieldConfig::bn254(),
         };
 
-        for (kind, op, sign) in [
-            (USub, IntOp::Sub, Sign::Unsigned),
-            (SSub, IntOp::Sub, Sign::Signed),
-            (UDiv, IntOp::Div, Sign::Unsigned),
-            (SDiv, IntOp::Div, Sign::Signed),
-            (URem, IntOp::Rem, Sign::Unsigned),
-            (SRem, IntOp::Rem, Sign::Signed),
-            (UShr, IntOp::Shr, Sign::Unsigned),
-            (SShr, IntOp::Shr, Sign::Signed),
+        // The model op is written out beside the opcode rather than taken from the `From` impl,
+        // so that this pins the mapping instead of restating it.
+        for (kind, op) in [
+            (USub, IntOp::USub),
+            (SSub, IntOp::SSub),
+            (UDiv, IntOp::UDiv),
+            (SDiv, IntOp::SDiv),
+            (URem, IntOp::URem),
+            (SRem, IntOp::SRem),
+            (UShr, IntOp::UShr),
+            (SShr, IntOp::SShr),
         ] {
             for bits in [8usize, 32] {
                 for a in corners::values(bits) {
                     for b in corners::values(bits) {
-                        let got = match Value::Int(bits, a).binary_arith_op(
-                            &Value::Int(bits, b),
+                        let got = match Value::int(bits, a).binary_arith_op(
+                            &Value::int(bits, b),
                             &kind,
                             &mut dummy,
                         ) {
-                            Value::Int(width, v) => {
-                                assert_eq!(width, bits, "{kind:?} changed the result's width");
-                                v
+                            Value::Int(v) => {
+                                assert_eq!(v.bits(), bits, "{kind:?} changed the result's width");
+                                host_word(&v)
                             }
                             other => panic!("expected an integer result, got {other:?}"),
                         };
 
                         assert_eq!(
                             got,
-                            residue(op, sign, bits, a, bits, b).unwrap_or(0),
+                            residue(
+                                op,
+                                &IntBits::from_u128(bits, a),
+                                &IntBits::from_u128(bits, b),
+                            )
+                            .map_or(0, |v| host_word(&v)),
                             "{kind:?} at {bits} bits disagreed on {a:#x}, {b:#x}"
                         );
                     }
@@ -2354,19 +2539,15 @@ mod tests {
 
     #[test]
     fn integer_to_bits_zero_pads_past_u128() {
-        let Value::Array(bits) = Value::Int(8, 5).to_bits(&Endianness::Little, 130) else {
+        let Value::Array(bits) = Value::int(8, 5).to_bits(&Endianness::Little, 130) else {
             panic!("ToBits must produce an array");
         };
 
         assert_eq!(bits.len(), 130);
-        assert!(matches!(bits[0], Value::Int(1, 1)));
-        assert!(matches!(bits[1], Value::Int(1, 0)));
-        assert!(matches!(bits[2], Value::Int(1, 1)));
-        assert!(
-            bits[128..]
-                .iter()
-                .all(|bit| matches!(bit, Value::Int(1, 0)))
-        );
+        assert!(is_bit(&bits[0], 1));
+        assert!(is_bit(&bits[1], 0));
+        assert!(is_bit(&bits[2], 1));
+        assert!(bits[128..].iter().all(|bit| is_bit(bit, 0)));
     }
 
     #[test]
@@ -2378,14 +2559,10 @@ mod tests {
         };
 
         assert_eq!(bits.len(), 260);
-        assert!(
-            bits[..257]
-                .iter()
-                .all(|bit| matches!(bit, Value::Int(1, 0)))
-        );
-        assert!(matches!(bits[257], Value::Int(1, 1)));
-        assert!(matches!(bits[258], Value::Int(1, 0)));
-        assert!(matches!(bits[259], Value::Int(1, 1)));
+        assert!(bits[..257].iter().all(|bit| is_bit(bit, 0)));
+        assert!(is_bit(&bits[257], 1));
+        assert!(is_bit(&bits[258], 0));
+        assert!(is_bit(&bits[259], 1));
     }
 
     /// Witness lowering makes the decomposition cost visible as one one-bit rangecheck per bit

--- a/compiler/src/compiler/analysis/points_to/array_cells.rs
+++ b/compiler/src/compiler/analysis/points_to/array_cells.rs
@@ -562,7 +562,7 @@ fn record_index(
 
 fn const_index(ssa: &HLSSA, index: ValueId) -> Option<usize> {
     match &*ssa.get_const(index)? {
-        Constant::Int(_, v) => Some(*v as usize),
+        Constant::Int(v) => usize::try_from(v).ok(),
         _ => None,
     }
 }

--- a/compiler/src/compiler/analysis/points_to/builder.rs
+++ b/compiler/src/compiler/analysis/points_to/builder.rs
@@ -2,7 +2,7 @@
 //!
 //! For each function it emits the inclusion constraints of every opcode into a [`ConstraintSet`],
 //! plus the value nodes whose points-to set _escapes_ to a true program sink (a global, or — for
-//! `main` — a return). Calls are no longer modeled by blanket escape: a `Call` **instantiates the
+//! `main` — a return). Calls are not modeled by blanket escape: a `Call` **instantiates the
 //! callee's [`PointsToSummary`]** (see [`super::summary`]), so a ref passed to a callee that does
 //! not leak it stays local, and a ref returned from a callee resolves to the callee's actual object
 //! rather than `External`.
@@ -240,7 +240,7 @@ impl FnBuilder<'_> {
     /// The constant value of `index`, if any.
     fn const_index(&self, index: ValueId) -> Option<usize> {
         match &*self.ssa.get_const(index)? {
-            Constant::Int(_, v) => Some(*v as usize),
+            Constant::Int(v) => usize::try_from(v).ok(),
             _ => None,
         }
     }

--- a/compiler/src/compiler/analysis/symbolic_executor.rs
+++ b/compiler/src/compiler/analysis/symbolic_executor.rs
@@ -2,6 +2,7 @@
 //! into by providing their own `Value` and `Context` implementations that specialize it for their
 //! use-case.
 
+use mavros_int_semantics::IntBits;
 use tracing::{Level, instrument};
 
 use crate::{
@@ -125,9 +126,8 @@ where
         ctx: &mut Context,
     ) -> Self;
     fn not(&self, out_type: &Type, ctx: &mut Context) -> Self;
-    /// A constant integer: `s` raw bits, with no reading attached. Every consumer that cares about
-    /// signedness takes it from the operation applied to the value, not from the value.
-    fn of_int(s: usize, v: u128, ctx: &mut Context) -> Self;
+    /// A constant integer, as a pattern with no inherent signedness.
+    fn of_int(v: &IntBits, ctx: &mut Context) -> Self;
     // FIELD-ASSUMPTION: L2-seam
     fn of_field(f: Field, ctx: &mut Context) -> Self;
     fn of_blob(elem_type: Type, elements: Vec<Self>, ctx: &mut Context) -> Self;
@@ -818,7 +818,7 @@ where
     V: Value<Ctx>,
 {
     match constant {
-        Constant::Int(size, val) => V::of_int(*size, *val, ctx),
+        Constant::Int(v) => V::of_int(v, ctx),
         Constant::Field(val) => V::of_field(*val, ctx),
         Constant::FnPtr(_) => {
             todo!("FnPtrConst in symbolic executor");

--- a/compiler/src/compiler/analysis/types.rs
+++ b/compiler/src/compiler/analysis/types.rs
@@ -23,7 +23,7 @@ use crate::{
 
 pub fn const_value_type(value: &Constant) -> Type {
     match value {
-        Constant::Int(size, _) => Type::int(*size),
+        Constant::Int(v) => Type::int(v.bits()),
         Constant::Field(_) => Type::field(),
         Constant::FnPtr(_) => Type::function(),
         Constant::Blob(blob) => Type::blob(blob.elem_type.clone(), blob.len()),
@@ -183,7 +183,7 @@ impl Types {
 
             for instruction in block.get_instructions() {
                 self.run_opcode(instruction, &mut function_info, function_types, field)
-                    .unwrap_or_else(|_| panic!("Error running opcode {:?}", instruction));
+                    .unwrap_or_else(|e| panic!("Error running opcode {instruction:?}: {e}"));
             }
         }
 
@@ -605,7 +605,7 @@ impl Types {
             OpCode::SExt {
                 result,
                 value,
-                from_bits: _,
+                from_bits,
                 to_bits,
             } => {
                 let value_type = function_info
@@ -616,7 +616,14 @@ impl Types {
                 // Widen (signed) to the target width, keeping the witness wrapper.
                 let inner = value_type.strip_witness();
                 let widened = match &inner.expr {
-                    TypeExpr::Int(_) => Type::int(*to_bits),
+                    // `from_bits` is a second copy of the operand's own width.
+                    TypeExpr::Int(operand_bits) if operand_bits == from_bits => Type::int(*to_bits),
+                    TypeExpr::Int(operand_bits) => {
+                        return Err(format!(
+                            "SExt declares from_bits {from_bits} \
+                             for a value of type int{operand_bits}"
+                        ));
+                    }
                     _ => panic!("SExt on non-integer type: {:?}", value_type),
                 };
                 let result_type = if value_type.is_witness_of() {
@@ -832,5 +839,45 @@ impl Analysis for TypeInfo {
     fn compute(ssa: &HLSSA, store: &AnalysisStore) -> Self {
         let cfg = store.get::<FlowAnalysis>();
         Types::new().run(ssa, cfg)
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::ssa::hlssa::builder::{HLEmitter, HLSSABuilder};
+
+    /// Type an `SExt` whose operand is an eight-bit constant but which declares `from_bits`.
+    fn sext_declaring(from_bits: usize) {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            sb.modify_function(main_id, |b| {
+                b.function.add_return_type(Type::int(16));
+                let entry = b.function.get_entry_id();
+                let mut e = b.test_block(entry);
+                let v = e.int_const(8, 0x80);
+                let widened = e.sext(v, from_bits, 16);
+                e.terminate_return(vec![widened]);
+            });
+        }
+        let flow = FlowAnalysis::run(&ssa);
+        let _ = Types::new().run(&ssa, &flow);
+    }
+
+    #[test]
+    fn a_sext_declaring_its_operands_own_width_types_fine() {
+        sext_declaring(8);
+    }
+
+    /// The check that lets every consumer of `SExt` read the width off the operand instead.
+    #[test]
+    #[should_panic(expected = "SExt declares from_bits 16 for a value of type int8")]
+    fn a_sext_declaring_a_width_its_operand_does_not_have_is_rejected() {
+        sext_declaring(16);
     }
 }

--- a/compiler/src/compiler/analysis/value_range_analysis.rs
+++ b/compiler/src/compiler/analysis/value_range_analysis.rs
@@ -35,6 +35,7 @@
 //! way avoids an `Option<Interval>` that every call site would have to unwrap.
 
 use mavros_artifacts::FieldConfig;
+use mavros_int_semantics::IntBits;
 use num_bigint::{BigInt, Sign};
 use num_traits::{One, Signed, ToPrimitive, Zero};
 use tracing::{Level, instrument, warn};
@@ -361,8 +362,8 @@ impl ValueRangeAnalysis {
             } => {
                 let in_r = range(bounds, *value);
                 // `(v >> offset) & mask(width)`, with the result keeping the _source's_ type. The
-                // mask is exact whenever the shifted value already fits, which subsumes the
-                // identity case a signed source used to need a rule of its own for.
+                // mask is exact whenever the shifted value already fits, which covers a signed
+                // source without needing a rule of its own.
                 let shifted = in_r.unsigned().div_const_pos(&(BigInt::one() << *offset));
                 let masked = if shifted.fits_in_unsigned_bits(*width) {
                     shifted
@@ -387,9 +388,9 @@ impl ValueRangeAnalysis {
             // transfer is sound exactly under the standing invariant that **every hint is pinned by
             // accompanying constraints** — `bit_range.rs::lower_witness_bit_range` and
             // `witness_bitwise.rs::wrap_shifted_product` are the pattern to follow. A hint written
-            // without them leaves the range describing the honest prover only, which is no longer
-            // merely imprecise now that consumers can ELIDE constraints on the strength of what
-            // this domain says.
+            // without them leaves the range describing the honest prover only, which is worse
+            // than imprecise: consumers ELIDE constraints on the strength of what this domain
+            // says.
             OpCode::WriteWitness {
                 result: Some(r),
                 value,
@@ -593,10 +594,9 @@ impl ValueRangeAnalysis {
     /// a count rather than as a bit pattern, so it needs no width agreement. Every other rule here
     /// reasons about the result's bit pattern and gives up if an operand is not a reading of it.
     ///
-    /// `kind` carries the sign as well as the operation, and both are read off it. It used to
-    /// arrive alongside a separate `signed` flag, which meant a caller could spell an `SDiv` with
-    /// `signed: false` — an operation the pipeline cannot produce — and have it silently mean
-    /// something.
+    /// `kind` carries the sign as well as the operation, and both are read off it. A separate
+    /// `signed` flag beside it would let a caller spell an `SDiv` with `signed: false` — an
+    /// operation the pipeline cannot produce — and have it silently mean something.
     #[allow(clippy::too_many_arguments)]
     fn binary_arith(
         kind: BinaryArithOpKind,
@@ -653,7 +653,7 @@ impl ValueRangeAnalysis {
 
                 // Signed division truncates toward zero while `div_const_pos` floors, and the two
                 // agree only for a non-negative dividend. An unsigned reading satisfies that by
-                // construction, so this gate is now vacuous on the unsigned side.
+                // construction, so the gate binds only on the signed side.
                 if !dividend.is_non_negative() {
                     return ValueRange::full(width);
                 }
@@ -683,8 +683,8 @@ impl ValueRangeAnalysis {
                 }
 
                 // Bitwise operations act on the raw pattern, so the unsigned readings bound them
-                // unconditionally. The old rule needed both operands to be non-negative because it
-                // had only the mathematical reading to work with; here the gate is vacuous.
+                // unconditionally — no non-negativity gate is needed, which one reasoning from the
+                // mathematical reading alone could not avoid.
                 let (Some(lh), Some(rh)) = (l.unsigned().hi(), r.unsigned().hi()) else {
                     return ValueRange::full(width);
                 };
@@ -1696,9 +1696,9 @@ impl ValueRange {
     /// Only the **unsigned** reading crosses the width boundary. It is the raw integer, so it means
     /// the same thing at any width; the signed reading is two's complement at the _old_ width and
     /// is a statement about a sign bit that has moved, so it is dropped and recovered by the
-    /// reduction rather than carried over. Carrying it is how a widening used to manufacture ⊥: a
-    /// `Bits(8)` `[200, 255]` has the signed reading `[−56, −1]`, and re-reading that at `Bits(16)`
-    /// asks for a pattern that is both `≥ 200` and `≥ 2^15`, which nothing satisfies.
+    /// reduction rather than carried over. Carrying it across would manufacture ⊥: a `Bits(8)`
+    /// `[200, 255]` has the signed reading `[−56, −1]`, and re-reading that at `Bits(16)` asks for
+    /// a pattern that is both `≥ 200` and `≥ 2^15`, which nothing satisfies.
     pub fn constrain_to(&self, width: Width) -> Self {
         if self.width == width {
             return self.clone();
@@ -2053,15 +2053,9 @@ fn opt_mul(a: Option<&BigInt>, b: Option<&BigInt>) -> Option<BigInt> {
     }
 }
 
-/// Convert a `Constant::Int(bits, encoded)` u128 bit pattern back to a signed `BigInt`.
+/// Convert the `u128` bit pattern a `Constant::Int` carries back to a signed `BigInt`.
 ///
 /// Two's-complement decode for any `bits ∈ [1, 128]`.
-///
-/// Test-only. `compute_constant_bounds` used to call this on the signed half of the constant tag;
-/// with one `Constant::Int` it names a constant by its raw pattern instead and lets the domain's
-/// reduction recover the signed reading. What survives here is the _statement_ of that equivalence
-/// — `the_two_routes_to_one_pattern_agree` is what stops the reduction quietly drifting from the
-/// decode it is supposed to reproduce.
 #[cfg(test)]
 fn signed_const_to_bigint(bits: usize, encoded: u128) -> BigInt {
     if bits == 0 {
@@ -2098,6 +2092,14 @@ fn field_to_bigint(f: &Field) -> BigInt {
     BigInt::from_bytes_le(Sign::Plus, &bytes_le)
 }
 
+/// Convert an integer constant's pattern to a `BigInt`, read as an unsigned magnitude.
+///
+/// Unsigned because the pattern carries no reading; the signed one is recovered by the domain's own
+/// reduction.
+fn pattern_to_bigint(pattern: &IntBits) -> BigInt {
+    BigInt::from(num_bigint::BigUint::from(pattern))
+}
+
 /// Pre-compute the singleton interval for every constant in the SSA's constant storage.
 ///
 /// Constants are module-level singletons shared across functions, so this runs once before the
@@ -2112,9 +2114,10 @@ fn compute_constant_bounds(ssa: &HLSSA) -> HashMap<ValueId, ValueRange> {
                 // domain carries both, and the reduction is canonical, so naming the pattern as an
                 // unsigned singleton recovers exactly the signed reading `from_signed` would have
                 // been handed. `the_two_routes_to_one_pattern_agree` pins that.
-                Constant::Int(bits, v) => {
-                    ValueRange::from_unsigned(Width::Bits(*bits), Interval::singleton(*v))
-                }
+                Constant::Int(v) => ValueRange::from_unsigned(
+                    Width::Bits(v.bits()),
+                    Interval::singleton(pattern_to_bigint(v)),
+                ),
                 Constant::Field(f) => ValueRange::from_unsigned(
                     Width::Field(field),
                     Interval::singleton(field_to_bigint(f)),
@@ -2284,9 +2287,8 @@ mod tests {
 
     #[test]
     fn non_scalar_is_unconstrained_in_both_readings() {
-        // The old domain answered `IntInterval::top()` for every non-numeric value, and the `_`
-        // transfer arm and the `ArrayToSlice`/`Map` cast arm both have to agree on one
-        // representation of "no information" or `changed` never settles.
+        // The `_` transfer arm and the `ArrayToSlice`/`Map` cast arm both have to agree on one
+        // representation of "no information" for a non-numeric value, or `changed` never settles.
         let r = ValueRange::full(Width::NonScalar);
         assert_eq!(r.unsigned(), &Interval::top());
         assert_eq!(r.signed(), &Interval::top());
@@ -2325,9 +2327,9 @@ mod tests {
 
     #[test]
     fn both_readings_of_one_pattern_stay_available() {
-        // The domain keeps both readings of every value and never picks between them by looking at
-        // a type -- there is no longer a type-level sign to look at. Consumers that need one ask
-        // for it by name, and which name they ask for follows their opcode.
+        // The domain keeps both readings of every value and never picks between them by looking
+        // at a type -- there is no type-level sign to look at. Consumers that need one ask for it
+        // by name, and which name they ask for follows their opcode.
         let r = ValueRange::from_unsigned(Width::Bits(8), iv(200, 200));
         assert_eq!(r.unsigned(), &iv(200, 200));
         assert_eq!(r.signed(), &iv(-56, -56));
@@ -2451,7 +2453,7 @@ mod tests {
         // The narrowing half of `constraining_to_a_wider_width_does_not_manufacture_bottom`, and
         // the same mistake: `[128, 255]` is representable at `Bits(8)` -- every one of those
         // patterns is a `u8` -- but read as two's complement _there_ it is negative, so carrying
-        // the old width's signed reading across and intersecting it with `signed_full(8)` used to
+        // the source width's signed reading across and intersecting it with `signed_full(8)` would
         // discard the whole top half of the range. The assertion `constrain_to` models is about
         // representability, which only the unsigned reading decides.
         let wide = ValueRange::from_unsigned(Width::Bits(16), iv(0, 200));
@@ -2487,7 +2489,7 @@ mod tests {
     fn field_arithmetic_wraps_instead_of_emptying() {
         // `MulConst` with a multiplier of `[2, 3]` and a value of `p - 1` produces a raw
         // `[2p - 2, 3p - 3]`. Intersecting that with `[0, p)` — which is what capping to the
-        // declared type used to do — reports a value that definitely exists as unreachable.
+        // declared type amounts to — reports a value that definitely exists as unreachable.
         let p = field_modulus(f());
         let raw = Interval::closed(&p - BigInt::from(1), &p - BigInt::from(1))
             .mul(&Interval::closed(2, 3));
@@ -2782,12 +2784,13 @@ mod tests {
     }
 
     #[test]
-    fn bitwise_operations_no_longer_need_non_negative_operands() {
+    fn bitwise_operations_bound_negative_operands() {
         use BinaryArithOpKind::*;
         let w = Width::Bits(8);
 
-        // Both operands negative as signed, which the old rule refused to bound at all. The raw
-        // patterns are 200..=255 and 254..=255, so the AND is capped by the smaller.
+        // Both operands negative as signed, which a rule reasoning from the mathematical reading
+        // could not bound at all. The raw patterns are 200..=255 and 254..=255, so the AND is
+        // capped by the smaller.
         let and = arith(And, w, &i8r(-56, -1), &i8r(-2, -1));
         assert_eq!(and.unsigned(), &iv(0, 255));
 
@@ -2813,7 +2816,8 @@ mod tests {
         let quot = arith(SDiv, w, &i8r(-8, -1), &i8r(2, 2));
         assert_eq!(quot.signed(), &Interval::signed_full(8));
 
-        // `x % d < d`, and `x % d <= x`: the second term is what the old rule was missing.
+        // `x % d < d`, and `x % d <= x`: both terms are needed, and the second is the one a
+        // divisor-only bound would miss.
         let rem = arith(URem, w, &u8r(0, 3), &u8r(10, 10));
         assert_eq!(rem.unsigned(), &iv(0, 3));
         let rem = arith(URem, w, &u8r(0, 200), &u8r(10, 10));
@@ -3632,18 +3636,18 @@ mod tests {
 /// other.
 #[cfg(test)]
 mod int_semantics_conformance {
-    use mavros_int_semantics::{self as semantics, IntOp, Outcome, Raw, corners};
+    use mavros_int_semantics::{self as semantics, IntBits, IntOp, Outcome, corners};
 
     use super::*;
 
     /// Whether a bit pattern is in γ of a range: admitted by both readings.
-    fn in_gamma(range: &ValueRange, bits: usize, v: Raw) -> bool {
+    fn in_gamma(range: &ValueRange, bits: usize, v: u128) -> bool {
         range.unsigned().contains(&BigInt::from(v))
             && range.signed().contains(&signed_const_to_bigint(bits, v))
     }
 
     /// Every bit pattern a range denotes, at a width small enough to enumerate.
-    fn gamma(range: &ValueRange, bits: usize) -> Vec<Raw> {
+    fn gamma(range: &ValueRange, bits: usize) -> Vec<u128> {
         assert!(bits <= 8, "γ is enumerated, so the width has to stay small");
         (0..=semantics::mask(bits))
             .filter(|v| in_gamma(range, bits, *v))
@@ -3659,7 +3663,7 @@ mod int_semantics_conformance {
         let width = Width::Bits(bits);
         let top = semantics::mask(bits);
         let half = top / 2;
-        let closed = |lo: Raw, hi: Raw| {
+        let closed = |lo: u128, hi: u128| {
             ValueRange::from_unsigned(width, Interval::closed(BigInt::from(lo), BigInt::from(hi)))
         };
 
@@ -3682,28 +3686,29 @@ mod int_semantics_conformance {
     ///
     /// Spelled out so that adding a `BinaryArithOpKind` is a compile error in a test that would
     /// otherwise silently stop covering it.
-    fn operations() -> Vec<(BinaryArithOpKind, IntOp, semantics::Sign)> {
+    fn operations() -> Vec<(BinaryArithOpKind, IntOp)> {
         use BinaryArithOpKind as K;
-        use semantics::Sign::{Signed, Unsigned};
 
         vec![
-            (K::UAdd, IntOp::Add, Unsigned),
-            (K::SAdd, IntOp::Add, Signed),
-            (K::USub, IntOp::Sub, Unsigned),
-            (K::SSub, IntOp::Sub, Signed),
-            (K::UMul, IntOp::Mul, Unsigned),
-            (K::SMul, IntOp::Mul, Signed),
-            (K::UDiv, IntOp::Div, Unsigned),
-            (K::SDiv, IntOp::Div, Signed),
-            (K::URem, IntOp::Rem, Unsigned),
-            (K::SRem, IntOp::Rem, Signed),
-            (K::UShl, IntOp::Shl, Unsigned),
-            (K::SShl, IntOp::Shl, Signed),
-            (K::UShr, IntOp::Shr, Unsigned),
-            (K::SShr, IntOp::Shr, Signed),
-            (K::And, IntOp::And, Unsigned),
-            (K::Or, IntOp::Or, Unsigned),
-            (K::Xor, IntOp::Xor, Unsigned),
+            (K::UAdd, IntOp::UAdd),
+            (K::SAdd, IntOp::SAdd),
+            (K::USub, IntOp::USub),
+            (K::SSub, IntOp::SSub),
+            (K::UMul, IntOp::UMul),
+            (K::SMul, IntOp::SMul),
+            (K::UDiv, IntOp::UDiv),
+            (K::SDiv, IntOp::SDiv),
+            (K::URem, IntOp::URem),
+            (K::SRem, IntOp::SRem),
+            // The one many-to-one pair: a left shift computes the same bits under both readings,
+            // so the model has a single `Shl`. See `From<BinaryArithOpKind> for IntOp`.
+            (K::UShl, IntOp::Shl),
+            (K::SShl, IntOp::Shl),
+            (K::UShr, IntOp::UShr),
+            (K::SShr, IntOp::SShr),
+            (K::And, IntOp::And),
+            (K::Or, IntOp::Or),
+            (K::Xor, IntOp::Xor),
         ]
     }
 
@@ -3715,7 +3720,7 @@ mod int_semantics_conformance {
             let width = Width::Bits(bits);
             let ranges = input_ranges(bits);
 
-            for (kind, op, sign) in operations() {
+            for (kind, op) in operations() {
                 for l in &ranges {
                     for r in &ranges {
                         // Both operands at the result's width, which is the case every rule here
@@ -3725,13 +3730,18 @@ mod int_semantics_conformance {
 
                         for a in gamma(l, bits) {
                             for b in gamma(r, bits) {
-                                let Outcome::Value(v) = semantics::eval(op, sign, bits, a, bits, b)
-                                else {
+                                let Outcome::Value(v) = semantics::eval(
+                                    op,
+                                    &IntBits::from_u128(bits, a),
+                                    &IntBits::from_u128(bits, b),
+                                ) else {
                                     // A rejected execution produces no value, so there is nothing
                                     // for the range to have contained.
                                     continue;
                                 };
 
+                                let v =
+                                    u128::try_from(&v).expect("a narrow answer fits a host word");
                                 assert!(
                                     in_gamma(&out, bits, v),
                                     "{kind:?} at {bits} bits: {a:#x} ∈ γ({l:?}) and {b:#x} ∈ \

--- a/compiler/src/compiler/codegen/bytecode/layout.rs
+++ b/compiler/src/compiler/codegen/bytecode/layout.rs
@@ -196,24 +196,22 @@ impl ConstantPoolInterner {
     }
 }
 
-/// Visit the `u64` words of `constant` in frame order — the order in which both the constant pool
-/// and a `MovConst` spill lay them out.
+/// Visit the `u64` words of `constant` in frame order.
 ///
 /// This is the single source of truth for constant word ordering: [`ConstantPoolInterner`], the
 /// `spill_constant_to_frame` inline path, and `constant_cell_count` (which just counts the visits)
-/// all drive it, so the pooled and inline representations — and the memcpy size — cannot drift out
+/// all use this, so the pooled and inline representations — and the memcpy size — cannot drift out
 /// of sync. Adding a new [`Constant`] variant only requires updating this function.
 pub fn for_each_constant_word(constant: &Constant, visit: &mut impl FnMut(u64)) {
     match constant {
-        // The word count is a question about the width alone.
-        Constant::Int(size, val) => match size {
-            bits if *bits <= 64 => visit(*val as u64),
-            128 => {
-                visit(*val as u64);
-                visit((*val >> 64) as u64);
+        Constant::Int(v) => {
+            // A normalised pattern already _is_ the word sequence, at exactly the length the frame
+            // wants. `int_cell_count` is called anyway, for the width cap it asserts on the way.
+            assert_eq!(int_cell_count(v.bits()), v.limb_count());
+            for &word in v.limbs() {
+                visit(word);
             }
-            bits => panic!("unsupported integer width: {bits}"),
-        },
+        }
         Constant::Field(val) => {
             // FIELD-ASSUMPTION: L3-felt-limbs
             // FIELD-ASSUMPTION: L3-frame
@@ -297,10 +295,8 @@ mod tests {
     #[test]
     fn the_two_frame_size_formulas_agree_at_every_width() {
         // `alloc_value` goes through `type_size` while `alloc_int` goes through `int_cell_count`,
-        // and the same value can be allocated by either. They used to disagree for anything
-        // needing more than one cell -- `type_size` hardcoded `1` for a signed integer, which was
-        // invisible only because a signed type could not be wider than 64 bits. Nothing bounds the
-        // width by sign any more, so the two must agree by construction.
+        // and the same value can be allocated by either, so the two formulas have to agree at every
+        // width.
         let layouter = FrameLayouter::new();
         for bits in [1usize, 8, 32, 63, 64, 65, 127, 128] {
             assert_eq!(
@@ -318,29 +314,33 @@ mod tests {
 
     #[test]
     fn a_constant_occupies_as_many_words_as_its_width_needs() {
-        // The word count follows the width, and `alloc_int` must agree with it -- the two used to
-        // disagree, and a wide constant lost its upper word.
+        // The word count follows the width, and `alloc_int` must agree with it: where they part
+        // company, a wide constant loses its upper word.
         let count = |c: &Constant| {
             let mut n = 0;
             for_each_constant_word(c, &mut |_| n += 1);
             n
         };
         for bits in [1usize, 8, 32, 63, 64] {
-            assert_eq!(count(&Constant::Int(bits, 1)), 1, "at {bits} bits");
+            assert_eq!(count(&Constant::int(bits, 1)), 1, "at {bits} bits");
         }
-        assert_eq!(count(&Constant::Int(128, 1)), 2);
+        assert_eq!(count(&Constant::int(128, 1)), 2);
+
+        for bits in [65usize, 96, 127] {
+            assert_eq!(count(&Constant::int(bits, 1)), 2, "at {bits} bits");
+        }
 
         // The upper word is emitted, not dropped: a payload living entirely above bit 64 must
         // still produce two words, the low one zero.
         let mut words = Vec::new();
-        for_each_constant_word(&Constant::Int(128, 1u128 << 100), &mut |w| words.push(w));
+        for_each_constant_word(&Constant::int(128, 1u128 << 100), &mut |w| words.push(w));
         assert_eq!(words, vec![0u64, 1u64 << 36]);
 
         // And the count agrees with what the frame reserves for the same width, which is the
         // pairing that actually has to hold.
-        for bits in [1usize, 8, 32, 63, 64, 128] {
+        for bits in [1usize, 8, 32, 63, 64, 65, 96, 127, 128] {
             assert_eq!(
-                count(&Constant::Int(bits, 1)),
+                count(&Constant::int(bits, 1)),
                 int_cell_count(bits),
                 "constant words and frame cells disagree at {bits} bits"
             );

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -88,7 +88,7 @@ fn materialize_constants(
         let constant = constants.get(&vid).expect("vid is in constants").as_ref();
         let cells = constant_cell_count(constant);
         let res = match constant {
-            hlssa::Constant::Int(size, _) => layouter.alloc_int(vid, *size),
+            hlssa::Constant::Int(v) => layouter.alloc_int(vid, v.bits()),
             hlssa::Constant::Field(_) => layouter.alloc_field(vid),
             hlssa::Constant::Blob(_) => layouter.alloc_long_data(vid, cells),
             hlssa::Constant::FnPtr(_) => panic!("FnPtr constants not supported in codegen"),

--- a/compiler/src/compiler/codegen/hlssa_to_r1cs.rs
+++ b/compiler/src/compiler/codegen/hlssa_to_r1cs.rs
@@ -4,7 +4,7 @@ use ark_ff::{AdditiveGroup, BigInt, BigInteger, Field, PrimeField};
 use tracing::{instrument, warn};
 
 use mavros_artifacts::FieldConfig;
-use mavros_int_semantics::{self as semantics, CmpOp, Sign};
+use mavros_int_semantics::{self as semantics, CmpOp, IntBits};
 
 use crate::compiler::{
     analysis::{
@@ -18,7 +18,7 @@ use crate::compiler::{
             Radix, RefCountOp, SliceOpDir, Type, TypeExpr, assert_signed_op_width,
         },
     },
-    util::{spread_bits, unspread_bits},
+    util::{host_word, spread_bits, unspread_bits},
 };
 
 pub use mavros_artifacts::{
@@ -202,8 +202,8 @@ impl Value {
             // FIELD-ASSUMPTION: L4-decompose
             Value::Const(c) => {
                 let limbs = c.into_bigint().0;
-                semantics::field_limbs_fit(&limbs, semantics::MAX_BITS)
-                    .then(|| semantics::field_limbs_to_int(&limbs, semantics::MAX_BITS))
+                IntBits::field_limbs_fit(&limbs, semantics::MAX_BITS)
+                    .then(|| host_word(&IntBits::from_field_limbs(&limbs, semantics::MAX_BITS)))
             }
             r => panic!("expected {what}, got {r:?}"),
         }
@@ -237,6 +237,14 @@ impl Value {
 
     pub fn expect_u128(&self) -> u128 {
         self.expect_in_u128("u128")
+    }
+
+    /// The canonical value as a `bits`-wide pattern.
+    ///
+    /// This evaluator carries its integers as field elements and reads them out as host words, so a
+    /// pattern exists only for the length of a call into the model.
+    fn expect_pattern(&self, bits: usize) -> IntBits {
+        IntBits::from_u128(bits, self.expect_u128())
     }
 
     // FIELD-ASSUMPTION: L4-eval
@@ -534,13 +542,9 @@ impl symbolic_executor::Value<R1CGen> for Value {
             CmpKind::ULt => self.lt(b),
             CmpKind::SLt => {
                 let bits = bits.expect("ICE: signed comparison without an operand width");
-                let less = semantics::cmp(
-                    CmpOp::Lt,
-                    Sign::Signed,
-                    bits,
-                    self.expect_u128(),
-                    b.expect_u128(),
-                );
+                let less = self
+                    .expect_pattern(bits)
+                    .compare(CmpOp::SLt, &b.expect_pattern(bits));
                 Value::Const(if less {
                     ark_bn254::Fr::ONE
                 } else {
@@ -591,14 +595,12 @@ impl symbolic_executor::Value<R1CGen> for Value {
                 // `int{max(s1, s2)}` and this evaluator only sees that result type, so a shift
                 // amount narrower than the value is indistinguishable from one declared at the
                 // value's own width. Reading it wider than it was declared is harmless as the extra
-                // bits are zero, and the model masks both patterns itself.
+                // bits are zero, and `expect_pattern` masks to `bits` on the way in as the model
+                // takes its operands already normalized and does no masking of its own.
                 let raw = semantics::residue(
-                    binary_arith_op_kind.group().into(),
-                    binary_arith_op_kind.sign(),
-                    bits,
-                    self.expect_u128(),
-                    bits,
-                    b.expect_u128(),
+                    binary_arith_op_kind.into(),
+                    &self.expect_pattern(bits),
+                    &b.expect_pattern(bits),
                 )
                 .unwrap_or_else(|| {
                     Self::ice_undefined_divmod(
@@ -608,7 +610,7 @@ impl symbolic_executor::Value<R1CGen> for Value {
                     )
                 });
 
-                Value::Const(ark_bn254::Fr::from(raw))
+                Value::Const(ark_bn254::Fr::from(host_word(&raw)))
             }
             TypeExpr::Field | TypeExpr::WitnessOf(_) => match binary_arith_op_kind.group() {
                 ArithGroup::Add => self.add(b),
@@ -672,13 +674,10 @@ impl symbolic_executor::Value<R1CGen> for Value {
 
                 // Read as two's complement, by the same model call above, so an assertion and the
                 // comparison it asserts on cannot disagree.
-                if !semantics::cmp(
-                    CmpOp::Lt,
-                    Sign::Signed,
-                    bits,
-                    a.expect_u128(),
-                    b.expect_u128(),
-                ) {
+                if !a
+                    .expect_pattern(bits)
+                    .compare(CmpOp::SLt, &b.expect_pattern(bits))
+                {
                     return Err(AssertionFailure::new(format!(
                         "assert_cmp lt (signed) failed: {a_val:?} >= {b_val:?}"
                     )));
@@ -816,8 +815,8 @@ impl symbolic_executor::Value<R1CGen> for Value {
         Value::Const(ark_bn254::Fr::from_bigint(BigInt::from_bits_le(&negated_bits)).unwrap())
     }
 
-    fn of_int(_s: usize, v: u128, _ctx: &mut R1CGen) -> Self {
-        Value::Const(ark_bn254::Fr::from(v))
+    fn of_int(v: &IntBits, _ctx: &mut R1CGen) -> Self {
+        Value::Const(ark_bn254::Fr::from(host_word(v)))
     }
 
     fn of_field(f: crate::compiler::Field, _ctx: &mut R1CGen) -> Self {
@@ -1793,8 +1792,8 @@ mod comparison_tests {
 
     /// A field element has no width and no sign, and its comparisons say so.
     ///
-    /// This is the case that used to reach `assert_cmp`'s non-integer arm, and it must keep
-    /// reaching the same answers now that the arm is selected by the opcode instead.
+    /// `assert_cmp` selects its arm by the opcode rather than by the operand's kind, so this is
+    /// the case that pins a field comparison to the same answers either way.
     #[test]
     fn a_field_comparison_needs_no_width() {
         let a = constant(2);
@@ -1812,7 +1811,7 @@ mod comparison_tests {
 
 #[cfg(test)]
 mod int_semantics_conformance {
-    use mavros_int_semantics::{IntOp, Raw, Sign, corners, residue};
+    use mavros_int_semantics::{IntBits, IntOp, Sign, corners, residue};
 
     use super::{BinaryArithOpKind, FieldConfig, R1CGen, Type, Value, symbolic_executor};
 
@@ -1837,8 +1836,21 @@ mod int_semantics_conformance {
         BinaryArithOpKind::Xor,
     ];
 
+    /// `residue` on the host words either side of it.
+    ///
+    /// This evaluator holds its integers as field elements and reads them out as host words, so a
+    /// pattern exists only for the length of a call into the model.
+    fn model(op: BinaryArithOpKind, bits: usize, a: u128, b: u128) -> Option<u128> {
+        residue(
+            op.into(),
+            &IntBits::from_u128(bits, a),
+            &IntBits::from_u128(bits, b),
+        )
+        .map(|v| u128::try_from(&v).expect("a narrow answer fits a host word"))
+    }
+
     /// Fold one operation the way `R1CGen` does, and read the answer back as a raw pattern.
-    fn fold(op: BinaryArithOpKind, bits: usize, a: Raw, b: Raw) -> Raw {
+    fn fold(op: BinaryArithOpKind, bits: usize, a: u128, b: u128) -> u128 {
         let mut generator = R1CGen::new(FieldConfig::bn254());
         <Value as symbolic_executor::Value<R1CGen>>::arith(
             &Value::Const(ark_bn254::Fr::from(a)),
@@ -1851,29 +1863,12 @@ mod int_semantics_conformance {
     }
 
     /// The widths this evaluator may be asked about, for one reading.
-    ///
-    /// The odd widths are deliberately absent for shifts and present for everything else, which is
-    /// the same restriction the VM and LLVM sweeps carry and for the same reason: the shared
-    /// [`mavros_int_semantics::masked_shift_amount`] is a mask rather than a modulo, so at a width
-    /// that is not a power of two it corrupts even an in-range amount (T10). Nothing builds a shift
-    /// at such a width — `witness_bitwise::lower_shift` asserts against it — so sweeping one here
-    /// would pin a disagreement no program can reach.
-    fn widths(op: BinaryArithOpKind) -> Vec<usize> {
-        let signed = op.is_signed();
-        corners::widths_for(signed)
-            .iter()
-            .copied()
-            .chain(
-                corners::ODD_WIDTHS
-                    .into_iter()
-                    .filter(|_| !matches!(op.group().into(), IntOp::Shl | IntOp::Shr)),
-            )
-            .filter(|bits| !signed || corners::signed_width_ok(*bits))
-            .collect()
+    fn widths(op: BinaryArithOpKind) -> &'static [usize] {
+        corners::widths_for(op.is_signed())
     }
 
-    fn operand_pairs(op: BinaryArithOpKind, bits: usize) -> Vec<(Raw, Raw)> {
-        let rhs = if matches!(op.group().into(), IntOp::Shl | IntOp::Shr) {
+    fn operand_pairs(op: BinaryArithOpKind, bits: usize) -> Vec<(u128, u128)> {
+        let rhs = if IntOp::from(op).is_shift() {
             corners::shift_amounts(bits, bits)
         } else {
             corners::values(bits)
@@ -1885,8 +1880,8 @@ mod int_semantics_conformance {
     }
 
     /// Whether the model declines to specify this input, which is the ICE case rather than a value.
-    fn unspecified(op: BinaryArithOpKind, bits: usize, a: Raw, b: Raw) -> bool {
-        residue(op.group().into(), op.sign(), bits, a, bits, b).is_none()
+    fn unspecified(op: BinaryArithOpKind, bits: usize, a: u128, b: u128) -> bool {
+        model(op, bits, a, b).is_none()
     }
 
     /// The R1CS fold answers exactly what a total backend must answer.
@@ -1899,9 +1894,9 @@ mod int_semantics_conformance {
         let mut checked = 0usize;
 
         for op in ALL_ARITH {
-            for bits in widths(op) {
+            for &bits in widths(op) {
                 for (a, b) in operand_pairs(op, bits) {
-                    let Some(want) = residue(op.group().into(), op.sign(), bits, a, bits, b) else {
+                    let Some(want) = model(op, bits, a, b) else {
                         continue;
                     };
                     let got = fold(op, bits, a, b);
@@ -1933,7 +1928,7 @@ mod int_semantics_conformance {
         let mut found = 0usize;
 
         for op in ALL_ARITH {
-            for bits in widths(op) {
+            for &bits in widths(op) {
                 for (a, b) in operand_pairs(op, bits) {
                     if !unspecified(op, bits, a, b) {
                         continue;
@@ -1941,7 +1936,10 @@ mod int_semantics_conformance {
                     found += 1;
 
                     assert!(
-                        matches!(op.group().into(), IntOp::Div | IntOp::Rem),
+                        matches!(
+                            IntOp::from(op),
+                            IntOp::UDiv | IntOp::SDiv | IntOp::URem | IntOp::SRem
+                        ),
                         "{op:?} at {bits} bits: {a:#x} {b:#x} is unspecified but is not a division"
                     );
 
@@ -1978,20 +1976,15 @@ mod int_semantics_conformance {
         fold(BinaryArithOpKind::SDiv, 8, 0x80, 0xFF);
     }
 
-    /// The regression T1 named: the fold used to mask a shift amount to 127 rather than to the
-    /// operand width, so `1u8 << 8` answered `0` here and `1` in the VM and LLVM.
-    ///
-    /// Latent, because a planted amount check dominates every shift, but latent by an argument
-    /// about a different pass, which is exactly the kind of claim that decays. This pins the
-    /// agreement itself.
     #[test]
-    fn an_out_of_range_shift_amount_masks_to_the_width() {
+    fn an_out_of_range_shift_amount_reduces_to_the_width() {
         assert_eq!(fold(BinaryArithOpKind::UShl, 8, 1, 8), 1);
         assert_eq!(fold(BinaryArithOpKind::UShl, 8, 1, 9), 2);
         assert_eq!(fold(BinaryArithOpKind::UShr, 8, 0x80, 8), 0x80);
 
-        // The signed right shift already masked to `bits - 1`, so it is here as the control: the
-        // trio agreed on `>>` and only `<<` was out of step.
+        // The signed right shift is here as the control: it reduces by the width like the other
+        // two, so a failure isolated to `<<` points at the shift direction rather than at the
+        // reduction.
         assert_eq!(fold(BinaryArithOpKind::SShr, 8, 0xFF, 8), 0xFF);
     }
 }

--- a/compiler/src/compiler/codegen/llssa_to_llvm.rs
+++ b/compiler/src/compiler/codegen/llssa_to_llvm.rs
@@ -22,6 +22,8 @@ use inkwell::{
     },
 };
 
+use mavros_int_semantics::IntBits;
+
 use crate::{
     collections::HashMap,
     compiler::{
@@ -327,15 +329,26 @@ impl<'ctx> LLVMCodeGen<'ctx> {
         }
     }
 
+    /// A `bits`-wide LLVM constant carrying `value`, little-endian.
     fn int_mask(&self, bits: u32, value: u128) -> IntValue<'ctx> {
-        let words = [value as u64, (value >> 64) as u64];
+        self.int_pattern(&IntBits::from_u128(bits as usize, value))
+    }
+
+    /// An LLVM constant carrying `pattern`, at the pattern's own width.
+    ///
+    /// The limbs go straight through: a normalised pattern is already exactly the little-endian
+    /// word sequence `const_int_arbitrary_precision` wants, at exactly the length it wants.
+    fn int_pattern(&self, pattern: &IntBits) -> IntValue<'ctx> {
+        let bits = u32::try_from(pattern.bits()).expect("An integer width fits a u32");
         self.context
             .custom_width_int_type(NonZeroU32::new(bits).expect("Cannot have zero-width integer"))
             .expect("A basic integer type can be created")
-            .const_int_arbitrary_precision(&words)
+            .const_int_arbitrary_precision(pattern.limbs())
     }
 
+    /// The low `bits` bits set, as a host `u128`.
     fn low_bits_mask(bits: u32) -> u128 {
+        assert!(bits <= 128, "a {bits}-bit mask does not fit in a u128");
         if bits == 128 {
             u128::MAX
         } else {
@@ -464,7 +477,7 @@ impl<'ctx> LLVMCodeGen<'ctx> {
     /// Materialise an LLSSA constant as an LLVM constant value, recursively.
     fn materialize_const(&self, c: &Constant) -> BasicValueEnum<'ctx> {
         match c {
-            Constant::Int { bits, value } => self.int_mask(*bits, *value).into(),
+            Constant::Int(pattern) => self.int_pattern(pattern).into(),
             Constant::NullPtr => self
                 .context
                 .ptr_type(AddressSpace::default())
@@ -960,34 +973,42 @@ impl<'ctx> LLVMCodeGen<'ctx> {
             IntArithOp::Or => self.builder.build_or(lhs, rhs, name).unwrap(),
             IntArithOp::Xor => self.builder.build_xor(lhs, rhs, name).unwrap(),
             IntArithOp::Shl => {
-                let masked_rhs = self.mask_shift_count(lhs, rhs);
+                let reduced_rhs = self.reduce_shift_count(lhs, rhs);
                 self.builder
-                    .build_left_shift(lhs, masked_rhs, name)
+                    .build_left_shift(lhs, reduced_rhs, name)
                     .unwrap()
             }
-            // `sign_extend` is the only difference between the two right shifts; the shift-count
-            // masking is identical and for the same reason as `Shl`.
             IntArithOp::UShr | IntArithOp::AShr => {
-                let masked_rhs = self.mask_shift_count(lhs, rhs);
+                let reduced_rhs = self.reduce_shift_count(lhs, rhs);
                 self.builder
-                    .build_right_shift(lhs, masked_rhs, matches!(kind, IntArithOp::AShr), name)
+                    .build_right_shift(lhs, reduced_rhs, matches!(kind, IntArithOp::AShr), name)
                     .unwrap()
             }
         }
     }
 
-    /// Hold a shift count below the operand width, as `count & (bit_width - 1)`.
+    /// Hold a shift count below the operand width, as `count % bit_width`.
     ///
-    /// LLVM makes a shift by at or past the width **poison**, so a total backend cannot simply pass
-    /// the count through. Masking is what the VM's `shift_amount` does with the same operands, so
-    /// the two backends answer the same thing on an amount neither should have been handed.
+    /// LLVM makes a shift by at or past the width into a **poison value**, so a total backend
+    /// cannot simply pass the count through. Reducing is what the VM's `shift_amount` does with the
+    /// same operands, so the two backends answer the same thing on an amount neither should have
+    /// been handed.
     ///
-    /// The mask is a genuine modulo only where the width is a power of two, which is every width a
-    /// shift is ever built at — `witness_bitwise::lower_shift` asserts exactly that.
-    fn mask_shift_count(&self, lhs: IntValue<'ctx>, rhs: IntValue<'ctx>) -> IntValue<'ctx> {
-        let bw = lhs.get_type().get_bit_width();
-        let mask = lhs.get_type().const_int(u64::from(bw - 1), false);
-        self.builder.build_and(rhs, mask, "shamt").unwrap()
+    /// A mask by `bit_width - 1` is that modulo only where the width is a power of two. At any
+    /// other width it is a submask: it stays below the width, but it corrupts counts that were
+    /// already _in range_, which `hlssa_to_r1cs` applies literally. So the power-of-two case keeps
+    /// the `and` and every other width gets a real `urem`.
+    fn reduce_shift_count(&self, lhs: IntValue<'ctx>, rhs: IntValue<'ctx>) -> IntValue<'ctx> {
+        let ty = lhs.get_type();
+        let bw = ty.get_bit_width();
+        if bw.is_power_of_two() {
+            let mask = ty.const_int(u64::from(bw - 1), false);
+            return self.builder.build_and(rhs, mask, "shamt").unwrap();
+        }
+        let width = ty.const_int(u64::from(bw), false);
+        self.builder
+            .build_int_unsigned_rem(rhs, width, "shamt")
+            .unwrap()
     }
 
     /// Lower one LLSSA instruction.
@@ -1727,6 +1748,26 @@ mod tests {
     };
 
     #[test]
+    fn a_low_bits_mask_is_exact_at_the_host_boundary() {
+        // 127 and 128 are the pair that a `1u128 << bits` gets wrong: the shift is defined only
+        // below 128, so the top of the range has to be answered without one.
+        assert_eq!(LLVMCodeGen::low_bits_mask(0), 0);
+        assert_eq!(LLVMCodeGen::low_bits_mask(1), 1);
+        assert_eq!(LLVMCodeGen::low_bits_mask(64), u64::MAX as u128);
+        assert_eq!(LLVMCodeGen::low_bits_mask(127), u128::MAX >> 1);
+        assert_eq!(LLVMCodeGen::low_bits_mask(128), u128::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not fit in a u128")]
+    fn a_mask_wider_than_the_host_is_rejected_rather_than_wrapped() {
+        // Without the assert this is `(1u128 << 129) - 1`, which panics in a debug build but
+        // _masks its shift amount_ in a release one and answers `1` -- a plausible number, and
+        // wrong. The rejection has to be explicit to be present at both optimisation levels.
+        let _ = LLVMCodeGen::low_bits_mask(129);
+    }
+
+    #[test]
     fn wasm_debug_sidecar_has_a_wasm_extension() {
         assert_eq!(
             wasm_debug_info_path(Path::new("target/program.wasm")),
@@ -1751,19 +1792,19 @@ mod tests {
             let one = block.emit_struct_const(
                 field_type.clone(),
                 vec![
-                    Constant::Int { bits: 64, value: 1 },
-                    Constant::Int { bits: 64, value: 0 },
-                    Constant::Int { bits: 64, value: 0 },
-                    Constant::Int { bits: 64, value: 0 },
+                    Constant::int(64, 1),
+                    Constant::int(64, 0),
+                    Constant::int(64, 0),
+                    Constant::int(64, 0),
                 ],
             );
             let two = block.emit_struct_const(
                 field_type,
                 vec![
-                    Constant::Int { bits: 64, value: 2 },
-                    Constant::Int { bits: 64, value: 0 },
-                    Constant::Int { bits: 64, value: 0 },
-                    Constant::Int { bits: 64, value: 0 },
+                    Constant::int(64, 2),
+                    Constant::int(64, 0),
+                    Constant::int(64, 0),
+                    Constant::int(64, 0),
                 ],
             );
             block.field_arith(FieldArithOp::Add, one, two);
@@ -1812,19 +1853,19 @@ mod tests {
 #[cfg(test)]
 mod int_semantics_conformance {
     use inkwell::{context::Context, values::AnyValue};
-    use mavros_int_semantics::{IntOp, Raw, Sign, corners, mask, residue};
+    use mavros_int_semantics::{IntBits, IntOp, corners, mask, residue};
 
     use super::*;
-    use crate::compiler::ssa::{hlssa::ArithGroup, hlssa_to_llssa::int_arith_op};
+    use crate::compiler::ssa::{hlssa::BinaryArithOpKind, hlssa_to_llssa::int_arith_op};
 
-    /// The `IntArithOp` a given model operation lowers to under a given reading.
+    /// The `IntArithOp` a given opcode lowers to.
     ///
     /// Delegates to the compiler's own table rather than restating it, so that this sweep covers
     /// the lowering's instruction choice as well as LLVM's definition of the instruction chosen.
     /// Note there is no `sshl`: a left shift is one map on the bit pattern, which is why
     /// `int_arith_op` ignores the sign for it just as the VM has no signed `cell_shl`.
-    fn lowering(op: IntOp, sign: Sign) -> IntArithOp {
-        int_arith_op(ArithGroup::from(op), sign.is_signed())
+    fn lowering(kind: BinaryArithOpKind) -> IntArithOp {
+        int_arith_op(kind.group(), kind.is_signed())
     }
 
     /// The raw pattern a folded constant holds, or [`None`] if LLVM did not fold it to one.
@@ -1834,7 +1875,7 @@ mod int_semantics_conformance {
     /// printed as `true`/`false` — which is the same corner the model calls out, `bool` being the
     /// one width whose only negative value is `1`. A `poison` matches none of these and yields
     /// [`None`], which is the intended reading of it here.
-    fn folded_pattern(value: IntValue<'_>, bits: usize) -> Option<Raw> {
+    fn folded_pattern(value: IntValue<'_>, bits: usize) -> Option<u128> {
         let printed = value.print_to_string().to_string();
         let literal = printed.rsplit(' ').next()?;
         let signed: i128 = match literal {
@@ -1842,20 +1883,7 @@ mod int_semantics_conformance {
             "false" => 0,
             other => other.parse().ok()?,
         };
-        Some((signed as Raw) & mask(bits))
-    }
-
-    /// Widths a shift is swept at.
-    ///
-    /// Powers of two only, and for exactly the reason `mask_shift_count` documents: `count &
-    /// (bit_width - 1)` is a modulo only there, and at a non-power-of-two width it corrupts
-    /// **in-range** counts as well.
-    fn shift_widths(sign: Sign) -> Vec<usize> {
-        corners::widths_for(sign.is_signed())
-            .iter()
-            .copied()
-            .filter(|bits| bits.is_power_of_two())
-            .collect()
+        Some((signed as u128) & mask(bits))
     }
 
     #[test]
@@ -1876,53 +1904,52 @@ mod int_semantics_conformance {
         let mut checked = 0usize;
         let mut unfolded = Vec::new();
 
-        for sign in Sign::ALL {
-            for op in IntOp::ALL {
-                let widths = if matches!(op, IntOp::Shl | IntOp::Shr) {
-                    shift_widths(sign)
+        // Driven from `BinaryArithOpKind`, the vocabulary being lowered *from*: the two are no
+        // longer in bijection, so sweeping the model's sixteen would cover only one of
+        // `UShl`/`SShl`. Shifts share the one width set, because `reduce_shift_count` emits a real
+        // `urem` off the power-of-two path rather than an `and` that is a modulo only there.
+        for kind in BinaryArithOpKind::ALL {
+            let op = IntOp::from(kind);
+            let sign = kind.sign();
+            for &bits in corners::widths_for(sign.is_signed()) {
+                let ty = context
+                    .custom_width_int_type(NonZeroU32::new(bits as u32).unwrap())
+                    .unwrap();
+                let rhs_values = if op.is_shift() {
+                    corners::shift_amounts(bits, bits)
                 } else {
-                    corners::widths_for(sign.is_signed()).to_vec()
+                    corners::values(bits)
                 };
 
-                for bits in widths {
-                    let ty = context
-                        .custom_width_int_type(NonZeroU32::new(bits as u32).unwrap())
-                        .unwrap();
-                    let rhs_values = if matches!(op, IntOp::Shl | IntOp::Shr) {
-                        corners::shift_amounts(bits, bits)
-                    } else {
-                        corners::values(bits)
-                    };
+                for a in corners::values(bits) {
+                    for b in &rhs_values {
+                        let lhs = ty.const_int_arbitrary_precision(&[a as u64, (a >> 64) as u64]);
+                        let rhs = ty.const_int_arbitrary_precision(&[*b as u64, (*b >> 64) as u64]);
+                        let val = codegen.build_int_arith(&lowering(kind), lhs, rhs, "");
 
-                    for a in corners::values(bits) {
-                        for b in &rhs_values {
-                            let lhs =
-                                ty.const_int_arbitrary_precision(&[a as u64, (a >> 64) as u64]);
-                            let rhs =
-                                ty.const_int_arbitrary_precision(&[*b as u64, (*b >> 64) as u64]);
-                            let val = codegen.build_int_arith(&lowering(op, sign), lhs, rhs, "");
+                        let Some(want) = residue(
+                            op,
+                            &IntBits::from_u128(bits, a),
+                            &IntBits::from_u128(bits, *b),
+                        )
+                        .map(|v| u128::try_from(&v).expect("a narrow answer fits a host word")) else {
+                            // The model declines; LLVM folds to `poison`. Nothing to compare,
+                            // and nothing may crash getting here, which is the whole claim.
+                            continue;
+                        };
 
-                            let Some(want) = residue(op, sign, bits, a, bits, *b) else {
-                                // The model declines; LLVM folds to `poison`. Nothing to compare,
-                                // and nothing may crash getting here, which is the whole claim.
-                                continue;
-                            };
-
-                            match folded_pattern(val, bits) {
-                                Some(got) => {
-                                    assert_eq!(
-                                        got, want,
-                                        "{op:?}/{sign:?} at {bits} bits: {a:#x} {b:#x} folded to \
-                                         {got:#x}, model says {want:#x}"
-                                    );
-                                    checked += 1;
-                                }
-                                // Recorded rather than asserted on the spot so that a folder that
-                                // stopped folding shows up as one summary rather than one failure.
-                                None => {
-                                    unfolded.push(format!("{op:?}/{sign:?} {bits} {a:#x} {b:#x}"))
-                                }
+                        match folded_pattern(val, bits) {
+                            Some(got) => {
+                                assert_eq!(
+                                    got, want,
+                                    "{op:?}/{sign:?} at {bits} bits: {a:#x} {b:#x} folded to \
+                                     {got:#x}, model says {want:#x}"
+                                );
+                                checked += 1;
                             }
+                            // Recorded rather than asserted on the spot so that a folder that
+                            // stopped folding shows up as one summary rather than one failure.
+                            None => unfolded.push(format!("{op:?}/{sign:?} {bits} {a:#x} {b:#x}")),
                         }
                     }
                 }

--- a/compiler/src/compiler/lowering/expression_converter.rs
+++ b/compiler/src/compiler/lowering/expression_converter.rs
@@ -978,7 +978,7 @@ impl<'a> ExpressionConverter<'a> {
                             // Only for the width gate: zero is zero under either reading, and the
                             // negation that consumes it takes its sign from its own opcode.
                             let (_, bits) = checked_int_cast_target(*signedness, *bit_size);
-                            Constant::Int(bits, 0)
+                            Constant::int(bits, 0)
                         }
                         _ => Constant::Field(b.field().constant(0u64)),
                     })
@@ -1260,7 +1260,7 @@ impl<'a> ExpressionConverter<'a> {
                 let elem_type = Type::int(8);
                 let elems = s
                     .iter()
-                    .map(|byte| Constant::Int(8, *byte as u128))
+                    .map(|byte| Constant::int(8, *byte as u128))
                     .collect();
                 let blob = b.emit_const(Constant::Blob(Blob::new(elem_type.clone(), elems)));
                 let location = self.current_source_location.clone();
@@ -1280,7 +1280,7 @@ impl<'a> ExpressionConverter<'a> {
                         FmtStrFragment::Interpolation(name, _) => format!("{{{name}}}"),
                     };
                     for c in text.chars() {
-                        codepoint_constants.push(Constant::Int(32, c as u128));
+                        codepoint_constants.push(Constant::int(32, c as u128));
                     }
                 }
                 let cp_len = codepoint_constants.len();
@@ -1409,7 +1409,7 @@ impl<'a> ExpressionConverter<'a> {
         match lit {
             Literal::Bool(bv) => {
                 let value = if *bv { 1 } else { 0 };
-                Some(Constant::Int(1, value))
+                Some(Constant::int(1, value))
             }
             Literal::Integer(field_element, typ, _location) => match typ {
                 AstType::Field => {
@@ -1425,20 +1425,16 @@ impl<'a> ExpressionConverter<'a> {
                             bits <= MAX_SUPPORTED_SIGNED_BITS,
                             "signed integers wider than i{MAX_SUPPORTED_SIGNED_BITS} are unsupported"
                         );
-                        // The _encoding_ still depends on the declared signedness even though the
-                        // constant no longer records it: a negative literal has to reach the IR as
-                        // its two's-complement pattern, which `to_u128` would not produce.
                         let val = field_element.to_i128();
-                        let twos_complement = (val as u128) & ((1u128 << bits) - 1);
-                        Some(Constant::Int(bits, twos_complement))
+                        Some(Constant::int(bits, val as u128))
                     } else {
                         let value = field_element.to_u128();
-                        Some(Constant::Int(bits, value))
+                        Some(Constant::int(bits, value))
                     }
                 }
                 AstType::Bool => {
                     let value = field_element.to_u128();
-                    Some(Constant::Int(1, value))
+                    Some(Constant::int(1, value))
                 }
                 _ => panic!("Unexpected type for integer literal: {:?}", typ),
             },
@@ -1453,7 +1449,7 @@ impl<'a> ExpressionConverter<'a> {
     fn constant_matches_type(constant: &Constant, typ: &Type) -> bool {
         match (constant, &typ.expr) {
             (Constant::Field(_), TypeExpr::Field) => true,
-            (Constant::Int(bits, _), TypeExpr::Int(type_bits)) => bits == type_bits,
+            (Constant::Int(v), TypeExpr::Int(type_bits)) => v.bits() == *type_bits,
             _ => false,
         }
     }
@@ -1617,7 +1613,7 @@ impl<'a> ExpressionConverter<'a> {
                         // function call that emits constraints), then return the
                         // compile-time-known length.
                         self.convert_expression(&call.arguments[0], b);
-                        let value = b.emit_const(Constant::Int(32, *len as u128));
+                        let value = b.emit_const(Constant::int(32, *len as u128));
                         Some(value)
                     }
                     noirc_frontend::monomorphization::ast::Type::Vector(_) => {
@@ -1684,7 +1680,7 @@ impl<'a> ExpressionConverter<'a> {
             "is_unconstrained" => {
                 let value = b
                     .ssa
-                    .add_const(Constant::Int(1, if self.in_unconstrained { 1 } else { 0 }));
+                    .add_const(Constant::int(1, if self.in_unconstrained { 1 } else { 0 }));
                 Some(value)
             }
             "as_witness" => {
@@ -1933,7 +1929,7 @@ fn checked_int_cast_target(
 
 /// The constant `1` a `for` loop steps by, at the index's width.
 fn index_step_one(bit_size: usize) -> Constant {
-    Constant::Int(bit_size, 1)
+    Constant::int(bit_size, 1)
 }
 
 /// Whether a Noir expression's value is read as two's complement.
@@ -1950,9 +1946,6 @@ fn index_step_one(bit_size: usize) -> Constant {
 ///
 /// That `None` is unreachable for anything this is asked about, and the enumeration above is the
 /// proof: a well-typed Noir program cannot make a statement the operand of an arithmetic operator.
-/// A cross-check between the two operands of a binary expression used to stand behind that claim
-/// as well; it was removed once it had run clean over the whole corpus twice, because it could only
-/// ever have caught input that Noir's own typechecker rejects first.
 fn operand_is_signed(e: &Expression) -> bool {
     matches!(e.return_type().as_deref(), Some(t) if ast_type_is_signed(t))
 }

--- a/compiler/src/compiler/passes/array_boundary_expansion.rs
+++ b/compiler/src/compiler/passes/array_boundary_expansion.rs
@@ -432,7 +432,7 @@ fn build_plan(ssa: &HLSSA, sel: &Selection) -> Plan {
         .max()
         .unwrap_or(0);
     plan.index_consts = (0..max_n)
-        .map(|k| ssa.add_const(Constant::Int(32, k as u128)))
+        .map(|k| ssa.add_const(Constant::int(32, k as u128)))
         .collect();
 
     // Callee plans (sorted callees; within each, params then return cells).

--- a/compiler/src/compiler/passes/array_sroa.rs
+++ b/compiler/src/compiler/passes/array_sroa.rs
@@ -464,7 +464,7 @@ fn array_size(ty: &Type) -> usize {
 /// The constant value of an index, if it resolves to an integer constant.
 fn const_index(ssa: &HLSSA, index: ValueId) -> Option<usize> {
     match &*ssa.get_const(index)? {
-        Constant::Int(_, v) => Some(*v as usize),
+        Constant::Int(v) => usize::try_from(v).ok(),
         _ => None,
     }
 }

--- a/compiler/src/compiler/passes/common_subexpression_elimination.rs
+++ b/compiler/src/compiler/passes/common_subexpression_elimination.rs
@@ -4,6 +4,8 @@
 //! This is a very simple CSE in comparison to PRE, and does elimination only to ensure that the
 //! witness shape remains frozen between the witness generator and AD programs.
 
+use mavros_int_semantics::IntBits;
+
 use crate::{
     collections::{HashMap, HashSet},
     compiler::{
@@ -154,7 +156,7 @@ impl CSE {
         let mut exprs: HashMap<ValueId, ExprId> = HashMap::default();
         for (vid, cv) in constants {
             let id = match cv.as_ref() {
-                Constant::Int(bits, value) => interner.int_const(*bits, *value),
+                Constant::Int(v) => interner.int_const(v.clone()),
                 Constant::Field(value) => interner.fconst(*value),
                 Constant::FnPtr(_) | Constant::Blob(_) => continue,
             };
@@ -707,7 +709,12 @@ impl CSE {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct ExprId(u32);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+// No `Ord` as this is an interning key, only ever hashed and compared for equality.
+//
+// The commutative chains sort their `ExprId`s, but never the nodes. Not having it matters because
+// `IntConst`'s payload deliberately has no ordering as it is an uninterpreted bit pattern with no
+// particular reading.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum ExprNode {
     /// The flattened commutative chains, carrying the sign of the operation that built them.
     ///
@@ -738,10 +745,7 @@ enum ExprNode {
         sign: Option<bool>,
     },
     FConst(Field),
-    IntConst {
-        bits: usize,
-        value: u128,
-    },
+    IntConst(IntBits),
     Variable(u64),
     Eq {
         lhs: ExprId,
@@ -841,8 +845,8 @@ impl ExprInterner {
         self.intern(ExprNode::FConst(value))
     }
 
-    fn int_const(&mut self, bits: usize, value: u128) -> ExprId {
-        self.intern(ExprNode::IntConst { bits, value })
+    fn int_const(&mut self, pattern: IntBits) -> ExprId {
+        self.intern(ExprNode::IntConst(pattern))
     }
 
     fn extend_adds(&self, expr: ExprId, signed: bool, out: &mut Vec<ExprId>) {
@@ -1019,6 +1023,21 @@ mod tests {
     use super::*;
     use crate::compiler::ssa::{Terminator, hlssa::Type};
 
+    #[test]
+    fn an_interned_constant_is_keyed_by_its_width_as_well_as_its_value() {
+        // The interner is what decides two expressions are the same expression, so a constant's key
+        // has to be the whole pattern. Keying on the value alone would make `1u8` and `1u32` one
+        // node, and any two expressions differing only there would merge.
+        let mut interner = ExprInterner::default();
+        let narrow = interner.int_const(IntBits::from(1u8));
+        let wide = interner.int_const(IntBits::from(1u32));
+        assert_ne!(narrow, wide);
+
+        // And the same pattern twice is the same node, which is the property that makes it an
+        // interner at all.
+        assert_eq!(narrow, interner.int_const(IntBits::from(1u8)));
+    }
+
     /// `main(x, y) { a = x op1 y; b = x op2 y; return (a, b) }`, run through CSE.
     ///
     /// Returns the two values the terminator carries afterwards. If the pass merged the second
@@ -1075,8 +1094,8 @@ mod tests {
     #[test]
     fn no_operation_merges_with_its_opposite_sign() {
         // Every group with two forms, not just the ones whose forms compute different values.
-        // `UAdd`/`SAdd` agree on every bit and used to merge here on that basis; what that misses
-        // is that the survivor's opcode is what picks the overflow check emitted downstream.
+        // `UAdd`/`SAdd` agree on every bit, but this is not a licence to merge them: the survivor's
+        // opcode is what picks the overflow check emitted downstream.
         use BinaryArithOpKind::*;
         for (unsigned, signed) in [
             (UAdd, SAdd),

--- a/compiler/src/compiler/passes/defunctionalize.rs
+++ b/compiler/src/compiler/passes/defunctionalize.rs
@@ -131,7 +131,7 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
     fnptr_entries.sort_by_key(|(vid, _)| vid.0);
     let mut fnptr_remap = ValueReplacements::new();
     for (fnptr_vid, fn_id) in &fnptr_entries {
-        let canon = ssa.add_const(Constant::Int(32, fn_id.0 as u128));
+        let canon = ssa.add_const(Constant::int(32, fn_id.0 as u128));
         fnptr_remap.insert(*fnptr_vid, canon);
     }
 
@@ -201,8 +201,8 @@ fn run_defunctionalize(ssa: &mut HLSSA) {
         }
     }
 
-    // 3d. Apply the FnPtr → U(32, ...) operand remap globally. This is the operand-rewriting
-    // step that used to be implicit when the FnPtr entry was rebound in place at the same vid.
+    // 3d. Apply the FnPtr → U(32, ...) operand remap globally. The canonical constant is minted
+    // at a fresh vid rather than rebound in place, so every operand has to be rewritten explicitly.
     for (_, func) in ssa.iter_functions_mut() {
         for (_, block) in func.get_blocks_mut() {
             for instr in block.get_instructions_mut() {

--- a/compiler/src/compiler/passes/instruction_lowering/witness_bitwise.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/witness_bitwise.rs
@@ -335,9 +335,15 @@ impl LowerWitnessBitwiseOps {
         let lhs_signed = kind.is_signed();
         let rhs_witness = context.types().get_value_type(rhs).is_witness_of();
 
-        // The check below indexes bit `log2(bits)` upwards as "too large", which is only the right
-        // test when `bits` is a power of two. Every Noir integer width is, but the lowering would
+        // The check below indexes bit `log2(bits)` upwards as "too large", and `emit_pow2_factor`'s
+        // table is keyed by `log2(bits)` so that membership is the amount bound. Both are only
+        // right when `bits` is a power of two. Every Noir integer width is, but the lowering would
         // be silently wrong rather than merely unsupported if that ever changed.
+        //
+        // This is the guard IR's own requirement: the _total_ evaluators (the VM, LLVM and the
+        // model) reduce an amount modulo the width and so agree at every width. Admitting a non
+        // power-of-two shift means rebuilding the check as a real `amount < bits` comparison and
+        // splitting the `2^n` factor, not deleting this assert.
         assert!(
             bits.is_power_of_two(),
             "the shift-amount check assumes a power-of-two integer width, got {bits}"
@@ -1273,7 +1279,7 @@ mod tests {
     fn every_table_backed_width_has_exactly_as_many_rows_as_amounts() {
         // The table is keyed by `log2(bits)` so that its row count is `1 << size`, the convention
         // every other width-keyed table follows. That works only because the legal amounts are
-        // `0..bits` and `bits` is a power of two: `shift_operand_bits` asserts the latter. If the
+        // `0..bits` and `bits` is a power of two: `lower_shift` asserts the latter. If the
         // two ever drift, membership stops being the amount bound and the lowering silently accepts
         // or rejects the wrong amounts.
         for bits in [8usize, 16, 32, 64, 128] {

--- a/compiler/src/compiler/passes/lookup_spilling.rs
+++ b/compiler/src/compiler/passes/lookup_spilling.rs
@@ -49,7 +49,7 @@ struct HelperKey {
 fn flag_is_const_one(consts: &HLSSAConstantsSnapshot, flag: ValueId, field: FieldConfig) -> bool {
     match consts.get(&flag).map(|c| &**c) {
         Some(Constant::Field(f)) => *f == field.one(),
-        Some(Constant::Int(_, v)) => *v == 1,
+        Some(Constant::Int(v)) => v.is_one(),
         _ => false,
     }
 }

--- a/compiler/src/compiler/passes/merge_identical_functions.rs
+++ b/compiler/src/compiler/passes/merge_identical_functions.rs
@@ -100,7 +100,7 @@ impl MergeIdenticalFunctions {
                 match c {
                     Constant::FnPtr(_) => true,
                     Constant::Blob(blob) => blob.elements.iter().any(contains_fn_ptr),
-                    Constant::Int(..) | Constant::Field(_) => false,
+                    Constant::Int(_) | Constant::Field(_) => false,
                 }
             }
             let mut has_fn_ptr = false;
@@ -540,7 +540,7 @@ mod tests {
                 fb.function.add_return_type(Type::int(32));
                 let entry = fb.function.get_entry_id();
                 let result = fb.fresh_value();
-                let c = fb.emit_const(Constant::Int(32, value));
+                let c = fb.emit_const(Constant::int(32, value));
                 let mut block = fb.test_block(entry);
                 let _x = block.add_parameter(Type::int(32));
                 block.emit_instruction(OpCode::Not { result, value: c });
@@ -811,7 +811,7 @@ mod tests {
                 fb.function.add_return_type(Type::field());
                 let entry = fb.function.get_entry_id();
                 let result = fb.fresh_value();
-                let condition = fb.emit_const(Constant::Int(1, 1));
+                let condition = fb.emit_const(Constant::int(1, 1));
                 let mut block = fb.test_block(entry);
                 let x = block.add_parameter(Type::field());
                 block.emit_instruction(OpCode::Guard {
@@ -863,7 +863,7 @@ mod tests {
         sb.modify_function(main_id, |fb| {
             let entry = fb.function.get_entry_id();
             let result = fb.fresh_value();
-            let condition = fb.emit_const(Constant::Int(1, 1));
+            let condition = fb.emit_const(Constant::int(1, 1));
             let arg = fb.emit_const(Constant::Field(fb.field().constant(7u64)));
             let mut block = fb.test_block(entry);
             block.emit_instruction(OpCode::Guard {

--- a/compiler/src/compiler/passes/partial_redundancy_elimination/test.rs
+++ b/compiler/src/compiler/passes/partial_redundancy_elimination/test.rs
@@ -226,7 +226,7 @@ fn integer_wrap_arithmetic_is_not_total() {
         Type::witness_of(Type::int(32)),
     ]);
     let (a, b, wa) = (vals[0], vals[1], vals[2]);
-    let c2 = ssa.add_const(Constant::Int(32, 2));
+    let c2 = ssa.add_const(Constant::int(32, 2));
     let r = ssa.fresh_value();
 
     let (fid, cc, types) = oracle_env(&ssa);
@@ -340,8 +340,8 @@ fn representation_casts_are_total_map_is_not() {
 fn division_requires_a_provably_nonzero_divisor() {
     let (ssa, vals) = main_with_params(&[Type::int(32), Type::int(32)]);
     let (x, d) = (vals[0], vals[1]);
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c2 = ssa.add_const(Constant::Int(32, 2));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c2 = ssa.add_const(Constant::int(32, 2));
     let r = ssa.fresh_value();
 
     let (fid, cc, types) = oracle_env(&ssa);
@@ -363,7 +363,7 @@ fn division_requires_a_provably_nonzero_divisor() {
 fn division_discharged_by_disequality_branch() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (x, d, eq) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
+    let c0 = ssa.add_const(Constant::int(32, 0));
     let r = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -398,14 +398,14 @@ fn division_discharged_by_disequality_branch() {
 /// disequality-only fact is insufficient, and the unsigned forms are unaffected.
 ///
 /// See [`narrow_signed_division_has_the_minus_one_hazard_too`] for why this is not a 64-bit-only
-/// concern, which is what it was originally written as.
+/// concern.
 #[test]
 fn signed_64_bit_division_minus_one_hazard() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (x, d, eq) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(64, 0));
-    let c2 = ssa.add_const(Constant::Int(64, 2));
-    let cm1 = ssa.add_const(Constant::Int(64, u64::MAX as u128));
+    let c0 = ssa.add_const(Constant::int(64, 0));
+    let c2 = ssa.add_const(Constant::int(64, 2));
+    let cm1 = ssa.add_const(Constant::int(64, u64::MAX as u128));
     let r = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -453,8 +453,8 @@ fn signed_64_bit_division_minus_one_hazard() {
 fn narrow_signed_division_has_the_minus_one_hazard_too() {
     let (ssa, vals) = main_with_params(&[Type::int(8)]);
     let x = vals[0];
-    let minus_one = ssa.add_const(Constant::Int(8, 0xFF));
-    let two = ssa.add_const(Constant::Int(8, 2));
+    let minus_one = ssa.add_const(Constant::int(8, 0xFF));
+    let two = ssa.add_const(Constant::int(8, 2));
     let r = ssa.fresh_value();
 
     let (fid, cc, types) = oracle_env(&ssa);
@@ -482,7 +482,7 @@ fn narrow_signed_division_has_the_minus_one_hazard_too() {
 fn unsigned_64_bit_all_ones_divisor_is_fine() {
     let (ssa, vals) = main_with_params(&[Type::int(64)]);
     let x = vals[0];
-    let ones = ssa.add_const(Constant::Int(64, u64::MAX as u128));
+    let ones = ssa.add_const(Constant::int(64, u64::MAX as u128));
     let r = ssa.fresh_value();
 
     let (fid, cc, types) = oracle_env(&ssa);
@@ -496,8 +496,8 @@ fn unsigned_64_bit_all_ones_divisor_is_fine() {
 fn shifts_require_a_constant_in_range_amount() {
     let (ssa, vals) = main_with_params(&[Type::int(32), Type::int(8)]);
     let (a, dyn_amount) = (vals[0], vals[1]);
-    let c5 = ssa.add_const(Constant::Int(8, 5));
-    let c40 = ssa.add_const(Constant::Int(8, 40));
+    let c5 = ssa.add_const(Constant::int(8, 5));
+    let c40 = ssa.add_const(Constant::int(8, 40));
     let r = ssa.fresh_value();
 
     let (fid, cc, types) = oracle_env(&ssa);
@@ -521,8 +521,8 @@ fn array_access_requires_a_constant_in_bounds_index() {
         Type::field(),
     ]);
     let (arr, slice, dyn_idx, elem) = (vals[0], vals[1], vals[2], vals[3]);
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let r = ssa.fresh_value();
 
     let (fid, cc, types) = oracle_env(&ssa);
@@ -649,8 +649,8 @@ fn effectful_and_witness_machinery_ops_are_never_total() {
 fn taint_source_gates_witness_ness_pre_untaint() {
     let (mut ssa, vals) = main_with_params(&[Type::int(32), Type::field().array_of(3)]);
     let (x, arr) = (vals[0], vals[1]);
-    let c2 = ssa.add_const(Constant::Int(32, 2));
-    let idx = ssa.add_const(Constant::Int(32, 1));
+    let c2 = ssa.add_const(Constant::int(32, 2));
+    let idx = ssa.add_const(Constant::int(32, 1));
     let (w, r) = (ssa.fresh_value(), ssa.fresh_value());
     ssa.get_unique_entrypoint_mut()
         .get_entry_mut()
@@ -947,9 +947,9 @@ fn mul_const_unifies_with_mul() {
 #[test]
 fn loop_carried_congruent_increments_redirect() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, j, cond, i2, j2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -1050,7 +1050,7 @@ fn lookup_dedup_respects_config() {
     let build = || {
         let (mut ssa, vals) = main_with_params(&[Type::field()]);
         let v = vals[0];
-        let flag = ssa.add_const(Constant::Int(1, 1));
+        let flag = ssa.add_const(Constant::int(1, 1));
         let f = ssa.get_unique_entrypoint_mut();
         let entry = f.get_entry_mut();
         for _ in 0..2 {
@@ -1236,7 +1236,7 @@ fn aggregate_constructors_are_untouched() {
 fn array_get_deduplicates() {
     let (mut ssa, vals) = main_with_params(&[Type::field().array_of(3)]);
     let arr = vals[0];
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (g1, g2) = (ssa.fresh_value(), ssa.fresh_value());
     let f = ssa.get_unique_entrypoint_mut();
     let entry = f.get_entry_mut();
@@ -1353,9 +1353,9 @@ fn invariant_loop(
 ) {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, cond, inv, i2, inv2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -1579,7 +1579,7 @@ fn pre_untaint_config_dedups_without_structural_change() {
 }
 
 /// The pre-untaint configuration's motion contract: a down-safe invariant behind a `Jmp`-terminated
-/// entry predecessor is hoisted (the site is no longer elimination-only), and the block/parameter
+/// entry predecessor is hoisted (the site is not elimination-only), and the block/parameter
 /// geometry still survives untouched — composed exactly as `PRE::run` composes transform and the
 /// integrated DCE.
 #[test]
@@ -1640,9 +1640,9 @@ fn tainted_invariant_loop(
 ) {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let c2f = ssa.add_const(Constant::Field(ssa.field().constant(2u64)));
     let (w, i, cond, inv, i2) = (
         ssa.fresh_value(),
@@ -1779,9 +1779,9 @@ fn post_loop_only_shape() -> (
 ) {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, cond, i2, post) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -1850,9 +1850,9 @@ fn post_loop_only_occurrence_is_not_hoisted() {
 #[test]
 fn loop_carried_operand_blocks_hoist() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let c1f = ssa.add_const(Constant::Field(ssa.field().constant(1u64)));
     let c2f = ssa.add_const(Constant::Field(ssa.field().constant(2u64)));
     let (j, acc, jc, x, k, kc, m1, k2, m2, j2) = (
@@ -1962,11 +1962,11 @@ fn outer_body_operand_shape(
 ) {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let c2 = if wrapping {
-        ssa.add_const(Constant::Int(32, 2))
+        ssa.add_const(Constant::int(32, 2))
     } else {
         ssa.add_const(Constant::Field(ssa.field().constant(2u64)))
     };
@@ -2146,9 +2146,9 @@ fn call_result_operand_shape(
     let g = ssa.add_function("g".to_string());
     let (p, r) = (ssa.fresh_value(), ssa.fresh_value());
     let (a, x) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let c2f = ssa.add_const(Constant::Field(ssa.field().constant(2u64)));
     let (j, jc, k, kc, m1, k2, m2, j2) = (
         ssa.fresh_value(),
@@ -2290,9 +2290,9 @@ fn nondet_call_result_operand_blocks_hoist() {
 fn aggregate_const_phi_operand_hoists_via_congruence_tier() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let idx = ssa.fresh_value();
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let ce1 = ssa.add_const(Constant::Field(ssa.field().constant(7u64)));
     let ce2 = ssa.add_const(Constant::Field(ssa.field().constant(9u64)));
     let (arr0, j, arr, jc, k, kc, x1, k2, x2, j2) = (
@@ -2518,9 +2518,9 @@ fn jmp_if_entry_edge_hoist_is_refused_when_preserving_structure() {
 fn multi_entry_header_is_skipped() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (c, a, b) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, cond, inv, i2, inv2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3252,9 +3252,9 @@ fn speculation_requires_the_speculate_level() {
 fn wrapping_integer_invariant_is_not_speculated() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, s, cond, u, i2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3308,9 +3308,9 @@ fn wrapping_integer_invariant_is_not_speculated() {
 fn guarded_division_is_speculated_where_the_fact_holds() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (x, d) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (eq, i, acc, cond, q, i2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3393,9 +3393,9 @@ fn guarded_division_is_speculated_where_the_fact_holds() {
 fn unguarded_division_is_not_speculated() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (x, d) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, acc, cond, q, i2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3489,9 +3489,9 @@ fn mul(
 fn hoisted_copy_carries_the_template_source_location() {
     let mut ssa = HLSSA::with_main("main".to_string());
     let (a, b) = (ssa.fresh_value(), ssa.fresh_value());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i, cond, inv, i2, inv2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -3627,10 +3627,10 @@ fn two_occurrences_of_one_expression_are_deduplicated() {
 
 #[test]
 fn no_operation_merges_with_its_opposite_sign() {
-    // Every group with two forms. `UAdd`/`SAdd` and friends used to merge here on the grounds that
-    // their results agree bit for bit; what that misses is that the survivor's opcode is what
-    // `LowerWitnessIntegerArithOps` reads to pick the overflow check, so the merge deletes one of
-    // the two checks. `noir_failure_tests/signed_unsigned_vn_merge` is the program it broke.
+    // Every group with two forms. `UAdd`/`SAdd` and friends agree bit for bit, which is not a
+    // licence to merge them: the survivor's opcode is what `LowerWitnessIntegerArithOps` reads to
+    // pick the overflow check, so merging deletes one of the two checks.
+    // `noir_failure_tests/signed_unsigned_vn_merge` is the program that catches it.
     use BinaryArithOpKind::*;
     for (unsigned, signed) in [
         (UAdd, SAdd),

--- a/compiler/src/compiler/passes/partial_redundancy_elimination/totality.rs
+++ b/compiler/src/compiler/passes/partial_redundancy_elimination/totality.rs
@@ -220,10 +220,10 @@ impl<'a> TotalityOracle<'a> {
         // disjunct from `1 << (bits - 1)` for any `bits` — so an `i8` division by a constant `-1`
         // can still fail, and speculating it moves that failure onto a path that did not have it.
         //
-        // This used to be gated on `bits == 64`, reasoning from the VM instead: `sdiv_int`
-        // sign-extends to i64, where only a 64-bit `MIN / -1` actually overflows. That is a true
-        // statement about `sdiv_int` and the wrong question — the check the speculation has to
-        // respect is the one mavros emits, not the one the interpreter would trap on.
+        // Reasoning from the VM instead would gate this on `bits == 64`: `sdiv_int` sign-extends
+        // to i64, where only a 64-bit `MIN / -1` actually overflows. That is a true statement about
+        // `sdiv_int` and the wrong question — the check the speculation has to respect is the one
+        // mavros emits, not the one the interpreter would trap on.
         let minus_one_hazard = kind.is_signed();
 
         if let Some(c) = self.cc.const_of(self.fid, divisor) {
@@ -256,10 +256,10 @@ impl<'a> TotalityOracle<'a> {
         let Some(c) = self.cc.const_of(self.fid, rhs) else {
             return false;
         };
-        let Some(amount) = constant_as_u128(&c) else {
+        let Some(amount) = constant_as_index(&c) else {
             return false;
         };
-        amount < lhs_ty.get_bit_size(self.ssa.field()) as u128
+        amount < lhs_ty.get_bit_size(self.ssa.field())
     }
 
     /// The index is a constant strictly below a _static_ array length.
@@ -278,10 +278,10 @@ impl<'a> TotalityOracle<'a> {
         let Some(c) = self.cc.const_of(self.fid, index) else {
             return false;
         };
-        let Some(i) = constant_as_u128(&c) else {
+        let Some(i) = constant_as_index(&c) else {
             return false;
         };
-        i < *len as u128
+        i < *len
     }
 }
 
@@ -311,7 +311,7 @@ pub enum WitnessnessSource<'a> {
 /// The zero constant of a scalar type, or `None` for non-scalar types.
 fn zero_constant_of(ty: &Type, field: FieldConfig) -> Option<Constant> {
     match &ty.expr {
-        TypeExpr::Int(bits) => Some(Constant::Int(*bits, 0)),
+        TypeExpr::Int(bits) => Some(Constant::int(*bits, 0)),
         TypeExpr::Field => Some(Constant::Field(field.zero())),
         _ => None,
     }
@@ -320,7 +320,7 @@ fn zero_constant_of(ty: &Type, field: FieldConfig) -> Option<Constant> {
 /// `true` if `c` is the zero of its scalar domain (`FnPtr`/`Blob` constants have none).
 fn constant_is_zero(c: &Constant, field: FieldConfig) -> bool {
     match c {
-        Constant::Int(_, v) => *v == 0,
+        Constant::Int(v) => v.is_zero(),
         Constant::Field(f) => *f == field.zero(),
         Constant::FnPtr(_) | Constant::Blob(_) => false,
     }
@@ -330,22 +330,15 @@ fn constant_is_zero(c: &Constant, field: FieldConfig) -> bool {
 /// signed constant.
 fn constant_is_all_ones(c: &Constant) -> bool {
     match c {
-        Constant::Int(bits, v) => {
-            let mask = if *bits >= 128 {
-                u128::MAX
-            } else {
-                (1u128 << bits) - 1
-            };
-            *v & mask == mask
-        }
+        Constant::Int(v) => v.is_all_ones(),
         Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => false,
     }
 }
 
-/// The raw bit pattern of an integer constant, or `None` for the non-integer variants.
-fn constant_as_u128(c: &Constant) -> Option<u128> {
+/// An integer constant read as a machine index, or `None` if it is not one it can be.
+fn constant_as_index(c: &Constant) -> Option<usize> {
     match c {
-        Constant::Int(_, v) => Some(*v),
+        Constant::Int(v) => usize::try_from(v).ok(),
         Constant::Field(_) | Constant::FnPtr(_) | Constant::Blob(_) => None,
     }
 }
@@ -369,7 +362,7 @@ fn constant_as_u128(c: &Constant) -> Option<u128> {
 /// `ArithGroup` fails to compile here, and changing the model's rejection set fails the assertion.
 #[cfg(test)]
 mod int_semantics_conformance {
-    use mavros_int_semantics::{IntOp, Sign, corners, eval};
+    use mavros_int_semantics::{IntBits, IntOp, corners, eval};
 
     use super::*;
 
@@ -400,11 +393,20 @@ mod int_semantics_conformance {
 
     /// Whether the model rejects this operation on any corner input at any width.
     fn can_reject(group: ArithGroup) -> bool {
-        let op: IntOp = group.into();
+        // The bitwise groups have one signed form and `Shl` has one model operation, so both signs
+        // land on the same `IntOp` for four of the ten groups; sweeping it twice would double the
+        // work and prove nothing the first pass did not.
+        let mut ops: Vec<IntOp> = Vec::new();
+        for signed in [false, true] {
+            let op: IntOp = BinaryArithOpKind::with_sign(group, signed).into();
+            if !ops.contains(&op) {
+                ops.push(op);
+            }
+        }
 
-        for sign in Sign::ALL {
-            for &bits in corners::widths_for(sign.is_signed()) {
-                let rhs = if matches!(op, IntOp::Shl | IntOp::Shr) {
+        for op in ops {
+            for &bits in corners::widths_for(op.is_signed()) {
+                let rhs = if op.is_shift() {
                     corners::shift_amounts(bits, bits)
                 } else {
                     corners::values(bits)
@@ -412,7 +414,13 @@ mod int_semantics_conformance {
 
                 for a in corners::values(bits) {
                     for b in &rhs {
-                        if eval(op, sign, bits, a, bits, *b).is_rejected() {
+                        if eval(
+                            op,
+                            &IntBits::from_u128(bits, a),
+                            &IntBits::from_u128(bits, *b),
+                        )
+                        .is_rejected()
+                        {
                             return true;
                         }
                     }

--- a/compiler/src/compiler/passes/shared/overflow_guard.rs
+++ b/compiler/src/compiler/passes/shared/overflow_guard.rs
@@ -636,19 +636,19 @@ mod tests {
 mod int_semantics_conformance {
     use super::*;
     use crate::compiler::analysis::value_range_analysis::{Interval, Width};
-    use mavros_int_semantics::{self as semantics, IntOp, Outcome, Raw, Sign, corners};
+    use mavros_int_semantics::{self as semantics, IntBits, IntOp, Outcome, corners};
     use num_bigint::BigInt;
 
     /// Whether a bit pattern is in γ of a range: admitted by both readings.
-    fn in_gamma(range: &ValueRange, bits: usize, v: Raw) -> bool {
+    fn in_gamma(range: &ValueRange, bits: usize, v: u128) -> bool {
         range.unsigned().contains(&BigInt::from(v))
             && range
                 .signed()
-                .contains(&BigInt::from(semantics::decode_signed(bits, v)))
+                .contains(&IntBits::from_u128(bits, v).to_signed())
     }
 
     /// Every bit pattern a range denotes, at a width small enough to enumerate.
-    fn gamma(range: &ValueRange, bits: usize) -> Vec<Raw> {
+    fn gamma(range: &ValueRange, bits: usize) -> Vec<u128> {
         (0..=semantics::mask(bits))
             .filter(|v| in_gamma(range, bits, *v))
             .collect()
@@ -664,7 +664,7 @@ mod int_semantics_conformance {
         let width = Width::Bits(bits);
         let top = semantics::mask(bits);
         let half = top / 2;
-        let closed = |lo: Raw, hi: Raw| {
+        let closed = |lo: u128, hi: u128| {
             ValueRange::from_unsigned(width, Interval::closed(BigInt::from(lo), BigInt::from(hi)))
         };
         let signed = |lo: i64, hi: i64| {
@@ -690,13 +690,9 @@ mod int_semantics_conformance {
         let mut discharged = 0usize;
 
         for bits in corners::EXHAUSTIVE_WIDTHS {
-            for (group, op) in [
-                (ArithGroup::Add, IntOp::Add),
-                (ArithGroup::Sub, IntOp::Sub),
-                (ArithGroup::Mul, IntOp::Mul),
-            ] {
-                for sign in Sign::ALL {
-                    let signed = sign.is_signed();
+            for group in [ArithGroup::Add, ArithGroup::Sub, ArithGroup::Mul] {
+                for signed in [false, true] {
+                    let op = IntOp::from(BinaryArithOpKind::with_sign(group, signed));
                     for l in &input_ranges(bits) {
                         for r in &input_ranges(bits) {
                             if !overflow_provably_impossible(l, r, group, bits, signed) {
@@ -706,10 +702,14 @@ mod int_semantics_conformance {
 
                             for a in gamma(l, bits) {
                                 for b in gamma(r, bits) {
-                                    let outcome = semantics::eval(op, sign, bits, a, bits, b);
+                                    let outcome = semantics::eval(
+                                        op,
+                                        &IntBits::from_u128(bits, a),
+                                        &IntBits::from_u128(bits, b),
+                                    );
                                     assert!(
                                         !matches!(outcome, Outcome::Rejected(_)),
-                                        "{group:?}/{sign:?} at {bits} bits discharged the check \
+                                        "{op:?} at {bits} bits discharged the check \
                                          for {l:?} and {r:?}, but {a:#x} {b:#x} is {outcome:?}"
                                     );
                                 }

--- a/compiler/src/compiler/passes/shared/shift_guard.rs
+++ b/compiler/src/compiler/passes/shared/shift_guard.rs
@@ -42,19 +42,16 @@ use crate::compiler::{
 /// This is the shift's counterpart of [`super::divmod_guard::divmod_can_fail`], and it returns the
 /// width rather than a `bool`: the amount is checked against the shifted value's width.
 ///
-/// The width is asserted to be a **power of two**. That is not something this module needs but
-/// something the backends assume. This is currently fine as every width Noir can name is a power
-/// of two and nothing in the compiler mints another.
+/// Any width is admitted as all evaluators reduce by `bits` now (`vm::shift_amount`,
+/// `llssa_to_llvm::reduce_shift_count`), so the agreement does not depend on the width's shape.
+///
+/// That does **not** mean a shift can be built at any width yet. The guard IR still needs one:
+/// `witness_bitwise::lower_shift` asserts a power of two because its amount check indexes bit
+/// `log2(bits)` and its `2^n` factor table is keyed by the same number. That assert is the live
+/// one; this is only about what the backends do with an amount that reaches them.
 pub fn shift_operand_bits(lhs_type: &Type) -> Option<usize> {
     match lhs_type.strip_witness().expr {
-        TypeExpr::Int(bits) => {
-            assert!(
-                bits.is_power_of_two(),
-                "a {bits}-bit shift: the amount bound checked here and the `bits - 1` mask the VM \
-                 and the WASM backend apply agree only at a power-of-two width"
-            );
-            Some(bits)
-        }
+        TypeExpr::Int(bits) => Some(bits),
         _ => None,
     }
 }

--- a/compiler/src/compiler/passes/simplifier.rs
+++ b/compiler/src/compiler/passes/simplifier.rs
@@ -21,7 +21,6 @@ use crate::{
                 builder::{HLFunctionBuilder, HLSSABuilder},
             },
         },
-        util::bit_mask,
     },
 };
 
@@ -545,7 +544,7 @@ fn materialize_zero(
 ) -> Option<Rewrite> {
     let field = fb.field();
     materialize_const(types, result, fb, move |t| match t {
-        TypeExpr::Int(s) => Some(Constant::Int(*s, 0)),
+        TypeExpr::Int(s) => Some(Constant::int(*s, 0)),
         TypeExpr::Field => Some(Constant::Field(field.zero())),
         _ => None,
     })
@@ -558,7 +557,7 @@ fn materialize_one(
 ) -> Option<Rewrite> {
     let field = fb.field();
     materialize_const(types, result, fb, move |t| match t {
-        TypeExpr::Int(s) => Some(Constant::Int(*s, 1)),
+        TypeExpr::Int(s) => Some(Constant::int(*s, 1)),
         TypeExpr::Field => Some(Constant::Field(field.one())),
         _ => None,
     })
@@ -566,7 +565,7 @@ fn materialize_one(
 
 fn is_zero(ssa: &HLSSA, v: ValueId) -> bool {
     match ssa.get_const(v).as_deref() {
-        Some(Constant::Int(_, 0)) => true,
+        Some(Constant::Int(pattern)) => pattern.is_zero(),
         Some(Constant::Field(f)) => f.is_zero(),
         _ => false,
     }
@@ -574,7 +573,7 @@ fn is_zero(ssa: &HLSSA, v: ValueId) -> bool {
 
 fn is_one(ssa: &HLSSA, v: ValueId) -> bool {
     match ssa.get_const(v).as_deref() {
-        Some(Constant::Int(_, 1)) => true,
+        Some(Constant::Int(pattern)) => pattern.is_one(),
         Some(Constant::Field(f)) => f.is_one(),
         _ => false,
     }
@@ -582,14 +581,14 @@ fn is_one(ssa: &HLSSA, v: ValueId) -> bool {
 
 fn is_all_ones(ssa: &HLSSA, v: ValueId) -> bool {
     match ssa.get_const(v).as_deref() {
-        Some(Constant::Int(bits, value)) => *value == bit_mask(*bits),
+        Some(Constant::Int(pattern)) => pattern.is_all_ones(),
         _ => false,
     }
 }
 
 fn const_as_usize(ssa: &HLSSA, v: ValueId) -> Option<usize> {
     match ssa.get_const(v).as_deref() {
-        Some(Constant::Int(_, value)) => (*value).try_into().ok(),
+        Some(Constant::Int(pattern)) => usize::try_from(pattern).ok(),
         _ => None,
     }
 }

--- a/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
+++ b/compiler/src/compiler/passes/sparse_conditional_simplification/test.rs
@@ -32,9 +32,9 @@ fn fold_and_dce(ssa: &mut HLSSA) {
 #[test]
 fn folds_constants_and_prunes_dead_branch() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c2 = ssa.add_const(Constant::Int(32, 2));
-    let c3 = ssa.add_const(Constant::Int(32, 3));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c2 = ssa.add_const(Constant::int(32, 2));
+    let c3 = ssa.add_const(Constant::int(32, 3));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (sum, is_five) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -119,9 +119,9 @@ fn folds_phi_of_agreeing_constants() {
 #[test]
 fn loop_variant_value_is_not_folded() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (i_param, lt, next) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -165,8 +165,8 @@ fn loop_variant_value_is_not_folded() {
 #[test]
 fn does_not_fold_overflow() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c200 = ssa.add_const(Constant::Int(8, 200));
-    let c100 = ssa.add_const(Constant::Int(8, 100));
+    let c200 = ssa.add_const(Constant::int(8, 200));
+    let c100 = ssa.add_const(Constant::int(8, 100));
     let sum = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -251,7 +251,7 @@ fn degenerate_loop_ices_on_stuck_condition() {
 #[test]
 fn select_with_constant_condition_aliases_to_arm() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (arm_t, arm_f, sel) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -281,7 +281,7 @@ fn select_with_constant_condition_aliases_to_arm() {
 #[test]
 fn branch_fact_folds_dominated_uses() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_false = ssa.add_const(Constant::Int(1, 0));
+    let c_false = ssa.add_const(Constant::int(1, 0));
     let (cond, arm_t, arm_f, selected, not_cond) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -429,7 +429,7 @@ fn branch_with_same_successor_does_not_infer_condition() {
 #[test]
 fn branch_fact_folds_phi_from_one_edge() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (cond, phi) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -467,7 +467,7 @@ fn branch_fact_folds_phi_from_one_edge() {
 #[test]
 fn folds_congruence_decided_branch() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b, eq) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -550,7 +550,7 @@ fn redundant_self_equality_assert_is_dropped() {
 #[test]
 fn redundant_congruent_equality_assert_is_dropped() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -674,11 +674,11 @@ fn witnessed_constant_is_cast_to_witness_of() {
 #[test]
 fn folds_constant_aggregate_projections() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c10 = ssa.add_const(Constant::Int(32, 10));
-    let c20 = ssa.add_const(Constant::Int(32, 20));
-    let c30 = ssa.add_const(Constant::Int(32, 30));
-    let idx = ssa.add_const(Constant::Int(32, 1));
-    let c_len = ssa.add_const(Constant::Int(32, 3));
+    let c10 = ssa.add_const(Constant::int(32, 10));
+    let c20 = ssa.add_const(Constant::int(32, 20));
+    let c30 = ssa.add_const(Constant::int(32, 30));
+    let idx = ssa.add_const(Constant::int(32, 1));
+    let c_len = ssa.add_const(Constant::int(32, 3));
     let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
@@ -725,7 +725,7 @@ fn folds_constant_aggregate_projections() {
 #[test]
 fn asserted_const_substituted_after_assert() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let b = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -785,7 +785,7 @@ fn asserted_const_substituted_after_assert_cmp_eq() {
 #[test]
 fn same_block_assert_is_index_granular() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (b, before, after) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -831,7 +831,7 @@ fn same_block_assert_is_index_granular() {
 #[test]
 fn known_unequal_folds_cmp_eq_to_false() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_false = ssa.add_const(Constant::Int(1, 0));
+    let c_false = ssa.add_const(Constant::int(1, 0));
     let (a, b, eq, eq2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -885,8 +885,8 @@ fn known_unequal_folds_cmp_eq_to_false() {
 #[test]
 fn known_unequal_folds_and_prunes_nested_jmpif() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c2 = ssa.add_const(Constant::Int(32, 2));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c2 = ssa.add_const(Constant::int(32, 2));
     let (a, b, eq, eq2) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -946,7 +946,7 @@ fn known_unequal_folds_and_prunes_nested_jmpif() {
 #[test]
 fn asserted_equal_folds_cmp_eq_to_true() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (a, b, eq) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1049,7 +1049,7 @@ fn witnessed_cmp_eq_folded_conditionally_is_cast_to_witness_of() {
 #[test]
 fn select_with_constant_false_condition_aliases_to_else_arm() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_false = ssa.add_const(Constant::Int(1, 0));
+    let c_false = ssa.add_const(Constant::int(1, 0));
     let (arm_t, arm_f, sel) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1080,7 +1080,7 @@ fn select_with_constant_false_condition_aliases_to_else_arm() {
 #[test]
 fn asserted_const_substituted_in_jmp_args() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (b, p) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1251,7 +1251,7 @@ fn asserted_equal_copy_propagates_to_dominating_leader() {
 #[test]
 fn asserted_equal_copy_prop_redirects_both_directions() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
+    let c0 = ssa.add_const(Constant::int(32, 0));
     let (a, b, before, after) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -1324,8 +1324,8 @@ fn asserted_equal_copy_prop_redirects_both_directions() {
 #[test]
 fn anticipated_copy_prop_to_block_defined_leader() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c2 = ssa.add_const(Constant::Int(32, 2));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c2 = ssa.add_const(Constant::int(32, 2));
     let (a, b, x, y, m) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -1497,7 +1497,7 @@ fn asserted_equal_copy_prop_reaches_jmp_args() {
 #[test]
 fn asserted_equal_copy_prop_yields_to_function_wide_fold() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (x, y, w, v) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -1686,7 +1686,7 @@ fn asserted_equal_copy_prop_keeps_establisher_under_dce() {
 #[test]
 fn congruence_dropped_assert_still_copy_propagates_soundly() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, a, b) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1743,14 +1743,14 @@ fn congruence_dropped_assert_still_copy_propagates_soundly() {
 /// without a separate cleanup pass. Fold-only would leave the operation (it is not constant); the
 /// full pass sweeps it.
 ///
-/// The dead instruction is a bitwise `And` rather than the add this used to use, because an add is
-/// a **partial op**: it can overflow, so DCE keeps a dead one rather than deleting it (see
+/// The dead instruction is a bitwise `And` rather than an add, because an add is a **partial op**:
+/// it can overflow, so DCE keeps a dead one rather than deleting it (see
 /// [`integrated_dce_keeps_a_dead_add_itself`] below). `And` has no failure mode at any width, so it
 /// is swept outright and still shows what this test is about.
 #[test]
 fn integrated_dce_removes_dead_code() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, unused) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1784,7 +1784,7 @@ fn integrated_dce_removes_dead_code() {
 #[test]
 fn integrated_dce_keeps_a_dead_add_itself() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
+    let c1 = ssa.add_const(Constant::int(32, 1));
     let (x, unused) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1822,7 +1822,7 @@ fn integrated_dce_keeps_a_dead_add_itself() {
 #[test]
 fn integrated_dce_rewrites_a_dead_mul_into_its_check() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 3));
+    let c1 = ssa.add_const(Constant::int(32, 3));
     let (x, unused) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -1859,10 +1859,10 @@ fn integrated_dce_rewrites_a_dead_mul_into_its_check() {
 #[test]
 fn integrated_dce_sweeps_dead_aggregate() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c10 = ssa.add_const(Constant::Int(32, 10));
-    let c20 = ssa.add_const(Constant::Int(32, 20));
-    let c30 = ssa.add_const(Constant::Int(32, 30));
-    let idx = ssa.add_const(Constant::Int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
+    let c20 = ssa.add_const(Constant::int(32, 20));
+    let c30 = ssa.add_const(Constant::int(32, 30));
+    let idx = ssa.add_const(Constant::int(32, 1));
     let (seq, got, len) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
 
     let entry = ssa.get_unique_entrypoint_mut().get_entry_mut();
@@ -1991,8 +1991,8 @@ fn conditional_jmpif_fold_orphan_is_reclaimed_same_run() {
 #[test]
 fn anticipated_const_folds_earlier_use() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let (x, r) = (ssa.fresh_value(), ssa.fresh_value());
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2098,7 +2098,7 @@ fn anticipated_cmp_fold_decides_branch() {
 #[test]
 fn mutual_erasure_keeps_one_assert() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c5 = ssa.add_const(Constant::Int(32, 5));
+    let c5 = ssa.add_const(Constant::int(32, 5));
     let v = ssa.fresh_value();
 
     let f = ssa.get_unique_entrypoint_mut();
@@ -2142,9 +2142,9 @@ fn mutual_erasure_keeps_one_assert() {
 #[test]
 fn loop_variant_value_not_rewritten_by_later_assert() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (v, used, lt, v1) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2212,9 +2212,9 @@ fn loop_variant_value_not_rewritten_by_later_assert() {
 #[test]
 fn anticipated_const_folds_post_loop_use() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c0 = ssa.add_const(Constant::Int(32, 0));
-    let c1 = ssa.add_const(Constant::Int(32, 1));
-    let c10 = ssa.add_const(Constant::Int(32, 10));
+    let c0 = ssa.add_const(Constant::int(32, 0));
+    let c1 = ssa.add_const(Constant::int(32, 1));
+    let c10 = ssa.add_const(Constant::int(32, 10));
     let (n, v, lt, v1, r) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2359,7 +2359,7 @@ fn bare_assert_over_cmp_chain_protected() {
 #[test]
 fn anticipated_witnessed_cmp_fold_redirects_use_via_hoisted_cast() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (a, b, ww) = (ssa.fresh_value(), ssa.fresh_value(), ssa.fresh_value());
     let cmp_location = SourceLocation::new(
         "src/main.nr",
@@ -2493,7 +2493,7 @@ fn anticipated_witnessed_cmp_fold_keeps_excluded_assert_use() {
 #[test]
 fn anticipated_witnessed_cmp_fold_from_post_dominating_assert() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (a, b, ww, s) = (
         ssa.fresh_value(),
         ssa.fresh_value(),
@@ -2566,7 +2566,7 @@ fn anticipated_witnessed_cmp_fold_from_post_dominating_assert() {
 #[test]
 fn anticipated_witness_cast_shared_with_asserted_const_channel() {
     let mut ssa = HLSSA::with_main("main".to_string());
-    let c_true = ssa.add_const(Constant::Int(1, 1));
+    let c_true = ssa.add_const(Constant::int(1, 1));
     let (a, b, w, ww) = (
         ssa.fresh_value(),
         ssa.fresh_value(),

--- a/compiler/src/compiler/passes/specializer.rs
+++ b/compiler/src/compiler/passes/specializer.rs
@@ -9,6 +9,8 @@ use ark_ff::BigInteger;
 use tracing::{info, instrument};
 
 use mavros_artifacts::FieldConfig;
+use mavros_int_semantics::IntBits;
+use num_bigint::BigUint;
 
 use crate::{
     collections::{HashMap, HashSet},
@@ -30,7 +32,7 @@ use crate::{
                 builder::{HLEmitter, HLFunctionBuilder},
             },
         },
-        util::{spread_bits, unspread_bits},
+        util::{host_word, spread_bits, unspread_bits},
     },
 };
 
@@ -51,7 +53,7 @@ fn folds_here(group: ArithGroup, lhs: &Constant) -> bool {
 /// `ValueId`s rather than a value this pass can evaluate.
 fn const_val_scalar(value: Option<&ConstVal>) -> Option<Constant> {
     match value? {
-        ConstVal::Int(s, v) => Some(Constant::Int(*s, *v)),
+        ConstVal::Int(v) => Some(Constant::Int(v.clone())),
         ConstVal::Field(f) => Some(Constant::Field(*f)),
         ConstVal::Array(_) | ConstVal::Blob(_) | ConstVal::BitsOf(..) => None,
     }
@@ -63,11 +65,12 @@ fn const_val_scalar(value: Option<&ConstVal>) -> Option<Constant> {
 /// constant, and for an operation that did not name a width. See [`Val::cmp`] for why the two
 /// widths agreeing is what lets the fold read one off the constant.
 fn assert_recorded_width(bits: Option<usize>, recorded: Option<&Constant>, kind: CmpKind) {
-    if let (Some(bits), Some(Constant::Int(s, v))) = (bits, recorded) {
+    if let (Some(bits), Some(Constant::Int(pattern))) = (bits, recorded) {
+        let s = pattern.bits();
         assert_eq!(
-            *s, bits,
-            "{kind:?} on a {bits}-bit operand whose recorded constant {v:#x} is {s}-bit: the two \
-             readings of that pattern differ"
+            s, bits,
+            "{kind:?} on a {bits}-bit operand whose recorded constant {pattern:?} is {s}-bit: the \
+             two readings of that pattern differ"
         );
     }
 }
@@ -78,9 +81,9 @@ fn assert_recorded_width(bits: Option<usize>, recorded: Option<&Constant>, kind:
 /// mints here is an input to the next instruction it walks.
 fn intern_folded(ctx: &mut SpecializationState, folded: Constant) -> Option<Val> {
     match folded {
-        Constant::Int(s, v) => {
-            let id = ctx.int_const(s, v);
-            ctx.const_vals.insert(id, ConstVal::Int(s, v));
+        Constant::Int(pattern) => {
+            let id = ctx.emit_constant(Constant::Int(pattern.clone()));
+            ctx.const_vals.insert(id, ConstVal::Int(pattern));
             Some(Val(id))
         }
         Constant::Field(f) => {
@@ -99,27 +102,37 @@ pub struct Specializer {
 #[derive(Debug, Clone)]
 // FIELD-ASSUMPTION: L4-eval
 enum ConstVal {
-    Int(usize, u128),
+    /// A raw two's-complement pattern, carrying its own width — as [`Constant::Int`] does, and for
+    /// the same reason: a width beside a payload is a second copy of a number that can drift.
+    Int(IntBits),
     Field(Field),
     Array(Vec<ValueId>),
     Blob(Vec<ValueId>),
     BitsOf(Box<ValueId>, usize, Endianness),
 }
 
-/// The width and raw payload of an integer `ConstVal`.
+/// A constant used as a machine index, refusing rather than truncating.
 ///
-/// Consumers that care about signedness decode with the width themselves, using the sign the
-/// _operation_ names. Returns `None` for non-integer constants, which never fold.
-fn int_bits_and_raw(value: Option<&ConstVal>) -> Option<(usize, u128)> {
+/// An `as usize` would let a value above `usize::MAX` land back inside a bounds check it should
+/// have failed.
+fn const_index(pattern: &IntBits) -> usize {
+    usize::try_from(pattern).expect("ICE: a constant index is wider than the machine")
+}
+
+/// The pattern an integer `ConstVal` carries.
+///
+/// Consumers that care about signedness decode it themselves, using the sign the _operation_
+/// names. Returns `None` for non-integer constants, which never fold.
+fn int_pattern(value: Option<&ConstVal>) -> Option<&IntBits> {
     match value? {
-        ConstVal::Int(s, v) => Some((*s, *v)),
+        ConstVal::Int(v) => Some(v),
         ConstVal::Field(_) | ConstVal::Array(_) | ConstVal::Blob(_) | ConstVal::BitsOf(..) => None,
     }
 }
 
 fn const_val_as_field(value: &ConstVal, field: FieldConfig) -> Option<Field> {
     match value {
-        ConstVal::Int(_, v) => Some(field.constant(*v)),
+        ConstVal::Int(v) => Some(field.constant(host_word(v))),
         ConstVal::Field(f) => Some(*f),
         _ => None,
     }
@@ -301,11 +314,11 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
     fn assert_bool(&self, ctx: &mut SpecializationState) -> Result<(), AssertionFailure> {
         let v_const = ctx.const_vals.get(&self.0).cloned();
         // Truthiness is a property of the bit pattern, so this reads either tag. A non-integer
-        // constant emits the assertion rather than panicking — declining to decide is always
-        // safe, and the previous `panic!` made an unmodelled constant a compiler crash.
-        match int_bits_and_raw(v_const.as_ref()) {
-            Some((_, val)) => {
-                if val == 0 {
+        // constant emits the assertion rather than panicking: declining to decide is always safe,
+        // where panicking would make an unmodelled constant a compiler crash.
+        match int_pattern(v_const.as_ref()) {
+            Some(val) => {
+                if val.is_zero() {
                     return Err(AssertionFailure::new("assert failed: value is zero"));
                 }
             }
@@ -327,10 +340,11 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
         let r_const = ctx.const_vals.get(&b.0);
         match kind {
             CmpKind::Eq => match (l_const, r_const) {
-                (Some(ConstVal::Int(_, l_val)), Some(ConstVal::Int(_, r_val))) => {
-                    if l_val != r_val {
+                (Some(ConstVal::Int(l_val)), Some(ConstVal::Int(r_val))) => {
+                    let (l_num, r_num) = (BigUint::from(l_val), BigUint::from(r_val));
+                    if l_num != r_num {
                         return Err(AssertionFailure::new(format!(
-                            "assert_cmp eq failed: {l_val} != {r_val}"
+                            "assert_cmp eq failed: {l_num} != {r_num}"
                         )));
                     }
                 }
@@ -373,23 +387,23 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
         let a_const = ctx.const_vals.get(&self.0).cloned();
         let index_const = ctx.const_vals.get(&index.0).cloned();
         match (a_const, index_const) {
-            (Some(ConstVal::Array(a) | ConstVal::Blob(a)), Some(ConstVal::Int(_, index))) => {
-                let res = a[index as usize];
+            (Some(ConstVal::Array(a) | ConstVal::Blob(a)), Some(ConstVal::Int(index))) => {
+                let res = a[const_index(&index)];
                 Self(res)
             }
             // FIELD-ASSUMPTION: L4-decompose
-            (Some(ConstVal::BitsOf(v, size, endianness)), Some(ConstVal::Int(_, index))) => {
+            (Some(ConstVal::BitsOf(v, size, endianness)), Some(ConstVal::Int(index))) => {
                 let v_const = ctx.const_vals.get(v.as_ref()).cloned();
                 match v_const {
                     Some(ConstVal::Field(f)) => {
                         let r = f.into_bigint().to_bits_le();
                         let ix = match endianness {
-                            Endianness::Little => index as usize,
-                            Endianness::Big => size - index as usize - 1,
+                            Endianness::Little => const_index(&index),
+                            Endianness::Big => size - const_index(&index) - 1,
                         };
-                        let res = if r[ix] { 1 } else { 0 };
-                        let res_v = ctx.int_const(1, res);
-                        ctx.const_vals.insert(res_v, ConstVal::Int(1, res));
+                        let bit = IntBits::from_u128(1, u128::from(r[ix]));
+                        let res_v = ctx.emit_constant(Constant::Int(bit.clone()));
+                        ctx.const_vals.insert(res_v, ConstVal::Int(bit));
                         Self(res_v)
                     }
                     _ => panic!("Not yet implemented {:?}", (v_const, endianness)),
@@ -457,7 +471,7 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
         let identity = match (cast_target, &c) {
             (
                 CastTarget::Nop | CastTarget::ArrayToSlice | CastTarget::WitnessOf,
-                Constant::Int(..) | Constant::Field(_),
+                Constant::Int(_) | Constant::Field(_),
             ) => true,
             (CastTarget::Field, Constant::Field(_)) => true,
             _ => false,
@@ -517,9 +531,9 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
         Self(HLEmitter::not(ctx, self.0))
     }
 
-    fn of_int(s: usize, v: u128, ctx: &mut SpecializationState) -> Self {
-        let val = ctx.int_const(s, v);
-        ctx.const_vals.insert(val, ConstVal::Int(s, v));
+    fn of_int(v: &IntBits, ctx: &mut SpecializationState) -> Self {
+        let val = ctx.emit_constant(Constant::Int(v.clone()));
+        ctx.const_vals.insert(val, ConstVal::Int(v.clone()));
         Self(val)
     }
 
@@ -536,7 +550,7 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
                 .get(&value)
                 .unwrap_or_else(|| panic!("Blob element v{} is not a constant", value.0))
             {
-                ConstVal::Int(bits, value) => Constant::Int(*bits, *value),
+                ConstVal::Int(pattern) => Constant::Int(pattern.clone()),
                 ConstVal::Field(value) => Constant::Field(*value),
                 ConstVal::Blob(elements) => {
                     let inner = typ.get_array_element();
@@ -601,7 +615,7 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
     fn expect_constant_bool(&self, ctx: &mut SpecializationState) -> bool {
         let val = ctx.const_vals.get(&self.0).unwrap();
         match val {
-            ConstVal::Int(_, v) => *v == 1,
+            ConstVal::Int(v) => v.is_one(),
             _ => todo!(),
         }
     }
@@ -616,8 +630,8 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
         let self_const = ctx.const_vals.get(&self.0);
 
         match self_const {
-            Some(ConstVal::Int(_, v)) => {
-                let res = if *v == 1 { if_t.0 } else { if_f.0 };
+            Some(ConstVal::Int(v)) => {
+                let res = if v.is_one() { if_t.0 } else { if_f.0 };
                 Self(res)
             }
             None => {
@@ -670,13 +684,14 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
     fn spread(&self, bits: u8, ctx: &mut SpecializationState) -> Self {
         let cst_val = ctx.const_vals.get(&self.0);
         match cst_val {
-            Some(ConstVal::Int(b, v)) => {
+            Some(ConstVal::Int(pattern)) => {
+                let b = pattern.bits();
                 assert!(
-                    *b <= 64,
-                    "Spread only supports integer widths up to 64 bits, got int{}",
-                    b
+                    b <= 64,
+                    "Spread only supports integer widths up to 64 bits, got int{b}"
                 );
-                Self::of_int(b * 2, spread_bits(*v, *b), ctx)
+                let spread = IntBits::from_u128(b * 2, spread_bits(host_word(pattern), b));
+                Self::of_int(&spread, ctx)
             }
             _ => {
                 let res = HLEmitter::spread(ctx, self.0, bits);
@@ -688,17 +703,17 @@ impl symbolic_executor::Value<SpecializationState<'_>> for Val {
     fn unspread(&self, bits: u8, ctx: &mut SpecializationState) -> (Self, Self) {
         let cst_val = ctx.const_vals.get(&self.0);
         match cst_val {
-            Some(ConstVal::Int(b, v)) => {
+            Some(ConstVal::Int(pattern)) => {
+                let b = pattern.bits();
                 assert!(
-                    *b <= MAX_SUPPORTED_UNSIGNED_BITS && b % 2 == 0,
-                    "Unspread expects an even integer width up to {MAX_SUPPORTED_UNSIGNED_BITS} bits, got int{}",
-                    b
+                    b <= MAX_SUPPORTED_UNSIGNED_BITS && b % 2 == 0,
+                    "Unspread expects an even integer width up to {MAX_SUPPORTED_UNSIGNED_BITS} bits, got int{b}"
                 );
                 let half_bits = b / 2;
-                let (odd, even) = unspread_bits(*v, *b);
+                let (odd, even) = unspread_bits(host_word(pattern), b);
                 (
-                    Self::of_int(half_bits, odd, ctx),
-                    Self::of_int(half_bits, even, ctx),
+                    Self::of_int(&IntBits::from_u128(half_bits, odd), ctx),
+                    Self::of_int(&IntBits::from_u128(half_bits, even), ctx),
                 )
             }
             _ => {
@@ -785,9 +800,9 @@ impl symbolic_executor::Context<Val> for SpecializationState<'_> {
 
     fn slice_len(&mut self, slice: &Val) -> Val {
         if let Some(ConstVal::Array(elements)) = self.const_vals.get(&slice.0) {
-            let len = elements.len() as u128;
-            let val = self.int_const(32, len);
-            self.const_vals.insert(val, ConstVal::Int(32, len));
+            let len = IntBits::from_u128(32, elements.len() as u128);
+            let val = self.emit_constant(Constant::Int(len.clone()));
+            self.const_vals.insert(val, ConstVal::Int(len));
             Val(val)
         } else {
             let val = HLEmitter::slice_len(self, slice.0);
@@ -955,10 +970,10 @@ impl Specializer {
                     call_params.push(Val(val));
                     const_vals.insert(val, ConstVal::Field(*f));
                 }
-                ValueSignature::Int { bits_size, value } => {
-                    let val = ssa.add_const(Constant::Int(*bits_size, *value));
+                ValueSignature::Int(pattern) => {
+                    let val = ssa.add_const(Constant::Int(pattern.clone()));
                     call_params.push(Val(val));
-                    const_vals.insert(val, ConstVal::Int(*bits_size, *value));
+                    const_vals.insert(val, ConstVal::Int(pattern.clone()));
                 }
             }
         }
@@ -1097,8 +1112,8 @@ impl Specializer {
                         let is_eq = entry.eq(*pval, cst);
                         cond = entry.and(cond, is_eq);
                     }
-                    ValueSignature::Int { bits_size, value } => {
-                        let cst = entry.int_const(*bits_size, *value);
+                    ValueSignature::Int(pattern) => {
+                        let cst = entry.emit_constant(Constant::Int(pattern.clone()));
                         let is_eq = entry.eq(*pval, cst);
                         cond = entry.and(cond, is_eq);
                     }
@@ -1172,31 +1187,129 @@ mod tests {
             .expect("HLSSA::new makes a main");
         let body = ssa.take_function(fid);
 
-        let lhs = ssa.add_const(Constant::Int(a.0, a.1));
-        let rhs = ssa.add_const(Constant::Int(b.0, b.1));
+        let lhs = ssa.add_const(Constant::int(a.0, a.1));
+        let rhs = ssa.add_const(Constant::int(b.0, b.1));
         let mut ctx = SpecializationState {
             ssa: &ssa,
             body,
             const_vals: HashMap::default(),
             current_location: SourceLocation::synthetic("specializer_test"),
         };
-        ctx.const_vals.insert(lhs, ConstVal::Int(a.0, a.1));
-        ctx.const_vals.insert(rhs, ConstVal::Int(b.0, b.1));
+        ctx.const_vals
+            .insert(lhs, ConstVal::Int(IntBits::from_u128(a.0, a.1)));
+        ctx.const_vals
+            .insert(rhs, ConstVal::Int(IntBits::from_u128(b.0, b.1)));
 
         let out = Val(lhs).arith(&Val(rhs), kind, &Type::int(a.0), &mut ctx);
         match ctx.const_vals.get(&out.0) {
-            Some(ConstVal::Int(s, v)) => Some((*s, *v)),
+            Some(ConstVal::Int(v)) => Some((v.bits(), host_word(v))),
             // Declined: `arith` emitted the shift instead, and its result has no constant.
             _ => None,
         }
     }
 
+    /// A constant `Eq` assertion answers on the operands' **values**, not on their widths.
+    ///
+    /// `IntBits`'s `PartialEq` includes the width, so comparing the patterns would turn a
+    /// mixed-width pair into a rejected program here while `instrumenter::cmp_op` (magnitudes) and
+    /// `hlssa_to_r1cs::assert_cmp` (field elements) accepted it. HLSSA's `Cmp` has no equal-width
+    /// typing rule, so nothing else makes such a pair unreachable.
+    #[test]
+    fn a_constant_eq_assertion_compares_values_and_not_widths() {
+        let mut ssa = HLSSA::new();
+        let fid = ssa
+            .get_function_ids()
+            .next()
+            .expect("HLSSA::new makes a main");
+        let body = ssa.take_function(fid);
+        let mut ctx = SpecializationState {
+            ssa: &ssa,
+            body,
+            const_vals: HashMap::default(),
+            current_location: SourceLocation::synthetic("specializer_test"),
+        };
+
+        let narrow = Val::of_int(&IntBits::from_u128(8, 1), &mut ctx);
+        let wide = Val::of_int(&IntBits::from_u128(32, 1), &mut ctx);
+        let other = Val::of_int(&IntBits::from_u128(8, 2), &mut ctx);
+
+        assert!(
+            Val::assert_cmp(CmpKind::Eq, &narrow, &wide, Some(8), &mut ctx).is_ok(),
+            "one value at two widths is one value"
+        );
+        assert!(Val::assert_cmp(CmpKind::Eq, &narrow, &narrow, Some(8), &mut ctx).is_ok());
+
+        // And the assertion still bites where the values genuinely differ, so the check above is
+        // not passing because the comparison stopped happening.
+        assert!(
+            Val::assert_cmp(CmpKind::Eq, &narrow, &other, Some(8), &mut ctx).is_err(),
+            "two different values must still be rejected"
+        );
+    }
+
+    /// A statically-failing `assert_eq` names its operands the way the Noir author wrote them.
+    ///
+    /// The message is the whole of what reaches a user here, and `IntBits`'s `Debug` is Verilog
+    /// sized-literal notation written for SSA dumps. Quoting it would report `8'hc8 != 8'h64` for
+    /// a program that says `200` and `100`.
+    #[test]
+    fn a_failed_constant_eq_names_its_operands_in_decimal() {
+        let mut ssa = HLSSA::new();
+        let fid = ssa
+            .get_function_ids()
+            .next()
+            .expect("HLSSA::new makes a main");
+        let body = ssa.take_function(fid);
+        let mut ctx = SpecializationState {
+            ssa: &ssa,
+            body,
+            const_vals: HashMap::default(),
+            current_location: SourceLocation::synthetic("specializer_test"),
+        };
+
+        let a = Val::of_int(&IntBits::from_u128(8, 200), &mut ctx);
+        let b = Val::of_int(&IntBits::from_u128(8, 100), &mut ctx);
+
+        let failure = Val::assert_cmp(CmpKind::Eq, &a, &b, Some(8), &mut ctx)
+            .expect_err("200 and 100 are not equal");
+        assert_eq!(failure.message, "assert_cmp eq failed: 200 != 100");
+    }
+
+    /// `of_int` records the constant at the width it was handed.
+    #[test]
+    fn a_seeded_constant_is_recorded_at_its_own_width() {
+        let mut ssa = HLSSA::new();
+        let fid = ssa
+            .get_function_ids()
+            .next()
+            .expect("HLSSA::new makes a main");
+        let body = ssa.take_function(fid);
+        let mut ctx = SpecializationState {
+            ssa: &ssa,
+            body,
+            const_vals: HashMap::default(),
+            current_location: SourceLocation::synthetic("specializer_test"),
+        };
+
+        // Two widths carrying the same payload, so a recorder that ignored the width would make
+        // them indistinguishable.
+        for bits in [8usize, 32] {
+            let seeded = Val::of_int(&IntBits::from_u128(bits, 1), &mut ctx);
+            let recorded = int_pattern(ctx.const_vals.get(&seeded.0));
+            assert_eq!(
+                recorded,
+                Some(&IntBits::from_u128(bits, 1)),
+                "a {bits}-bit seed was not recorded as one"
+            );
+        }
+    }
+
     #[test]
     fn unsigned_shl_folds_to_a_constant_inside_its_own_width() {
-        // The bug this pins: `1 << 32` at `u32` used to fold to `Constant::Int(32, 4294967296)`, a
-        // value one bit wider than the type it is tagged with. `hlssa_to_r1cs` wraps such a
-        // constant on the way in and reads `0` while the VM's `mov_const` carries the whole
-        // payload, so the two backends disagree about the program.
+        // What this pins: folding `1 << 32` at `u32` to a value one bit wider than the type it
+        // is tagged with. `hlssa_to_r1cs` wraps such a constant on the way in and reads `0` while
+        // the VM's `mov_const` carries the whole payload, so the two backends would disagree about
+        // the program.
         //
         // The amount is what fails, not the value, so `1 << 32` at `u32` does not fold at all.
         assert_eq!(specializer_shl((32, 1), (32, 32)), None);
@@ -1223,10 +1336,9 @@ mod tests {
         // wider amount would additionally narrow the result -- the type analysis types it as
         // `U(max(s1, s2))` -- but that is a second reason rather than the deciding one.
         //
-        // The narrower-amount direction used to fold, on the grounds that the *model* gives a shift
-        // amount a width of its own. It does, and that freedom is real for the evaluators that meet
-        // one at runtime; it is not a licence for a folder to mint IR the rest of the pipeline
-        // rejects.
+        // The narrower-amount direction is refused too, though the *model* does give a shift
+        // amount a width of its own. That freedom is real for the evaluators that meet one at
+        // runtime; it is not a licence for a folder to mint IR the rest of the pipeline rejects.
         assert_eq!(specializer_shl((8, 1), (32, 1)), None);
         assert_eq!(specializer_shl((32, 1), (8, 1)), None);
     }
@@ -1235,11 +1347,10 @@ mod tests {
     fn an_integer_fold_that_leaves_its_width_is_refused_rather_than_widened_or_panicking() {
         use BinaryArithOpKind::{SDiv, UAdd, UDiv, UShr, USub};
 
-        // Until the constant tags collapsed, these arms were seven hand-rolled `u128` operations
-        // reachable only for a pair that happened to be tagged `U`. They are the lattice's job now,
-        // which is what fixes all three of the following. Each line fails with the old arms
-        // restored -- the first by producing an over-wide constant, the second and third by
-        // _panicking_ in a debug build rather than declining.
+        // Every one of these goes through the lattice rather than through hand-rolled `u128`
+        // arithmetic here, which is what makes all three answer. Hand-rolled arms fail them: the
+        // first by producing an over-wide constant, the second and third by _panicking_ in a debug
+        // build rather than declining.
 
         // `u8 200 + 100` is 300, which does not fit in eight bits.
         assert_eq!(specializer_fold(UAdd, (8, 200), (8, 100)), None);

--- a/compiler/src/compiler/ssa/hlssa/builder.rs
+++ b/compiler/src/compiler/ssa/hlssa/builder.rs
@@ -230,7 +230,7 @@ pub trait HLEmitter {
     /// There is no signed/unsigned pair here because there is no sign to record: what the bits mean
     /// is decided by the opcode that consumes them.
     fn int_const(&mut self, bits: usize, value: u128) -> ValueId {
-        self.emit_constant(Constant::Int(bits, value))
+        self.emit_constant(Constant::int(bits, value))
     }
 
     // -- Witness --

--- a/compiler/src/compiler/ssa/hlssa/mod.rs
+++ b/compiler/src/compiler/ssa/hlssa/mod.rs
@@ -6,6 +6,8 @@ pub mod type_system;
 use itertools::Itertools;
 use std::fmt::Display;
 
+use mavros_int_semantics::IntBits;
+
 use crate::compiler::ssa::{
     Block, Function, FunctionId, Instruction, Located, SSA, SSAConstants, SSAConstantsSnapshot,
     SourceLocation, ValueId,
@@ -1942,48 +1944,77 @@ pub enum ArithGroup {
     Xor,
 }
 
-impl From<ArithGroup> for mavros_int_semantics::IntOp {
-    /// The reference model names the same ten operations, so this is a total renaming.
+impl From<BinaryArithOpKind> for mavros_int_semantics::IntOp {
+    /// The reference model names the same operations, so this is a many-to-one renaming
     ///
-    /// It is spelled out rather than derived so that adding a variant to either side is a compile
-    /// error here, which is the only place the two vocabularies meet.
-    fn from(group: ArithGroup) -> Self {
-        match group {
-            ArithGroup::Add => Self::Add,
-            ArithGroup::Sub => Self::Sub,
-            ArithGroup::Mul => Self::Mul,
-            ArithGroup::Div => Self::Div,
-            ArithGroup::Rem => Self::Rem,
-            ArithGroup::Shl => Self::Shl,
-            ArithGroup::Shr => Self::Shr,
-            ArithGroup::And => Self::And,
-            ArithGroup::Or => Self::Or,
-            ArithGroup::Xor => Self::Xor,
+    /// [`BinaryArithOpKind::UShl`] and [`BinaryArithOpKind::SShl`] both land on `IntOp::Shl`. A
+    /// left shift is one map on the bit pattern under either reading, and its amount is read as an
+    /// unsigned magnitude either way, so the model has a single variant; rejections are handled by
+    /// the guard IR rather than part of `eval`.
+    ///
+    /// We avoid deriving it so that adding a variant to either side is a compile error here.
+    fn from(kind: BinaryArithOpKind) -> Self {
+        use mavros_int_semantics::IntOp;
+        match kind {
+            BinaryArithOpKind::UAdd => IntOp::UAdd,
+            BinaryArithOpKind::SAdd => IntOp::SAdd,
+            BinaryArithOpKind::USub => IntOp::USub,
+            BinaryArithOpKind::SSub => IntOp::SSub,
+            BinaryArithOpKind::UMul => IntOp::UMul,
+            BinaryArithOpKind::SMul => IntOp::SMul,
+            BinaryArithOpKind::UDiv => IntOp::UDiv,
+            BinaryArithOpKind::SDiv => IntOp::SDiv,
+            BinaryArithOpKind::URem => IntOp::URem,
+            BinaryArithOpKind::SRem => IntOp::SRem,
+            BinaryArithOpKind::And => IntOp::And,
+            BinaryArithOpKind::Or => IntOp::Or,
+            BinaryArithOpKind::Xor => IntOp::Xor,
+            BinaryArithOpKind::UShl | BinaryArithOpKind::SShl => IntOp::Shl,
+            BinaryArithOpKind::UShr => IntOp::UShr,
+            BinaryArithOpKind::SShr => IntOp::SShr,
         }
     }
 }
 
-impl From<mavros_int_semantics::IntOp> for ArithGroup {
-    /// The inverse renaming, so that the two vocabularies are pinned to each other in both
-    /// directions.
-    fn from(op: mavros_int_semantics::IntOp) -> Self {
-        use mavros_int_semantics::IntOp;
-        match op {
-            IntOp::Add => Self::Add,
-            IntOp::Sub => Self::Sub,
-            IntOp::Mul => Self::Mul,
-            IntOp::Div => Self::Div,
-            IntOp::Rem => Self::Rem,
-            IntOp::Shl => Self::Shl,
-            IntOp::Shr => Self::Shr,
-            IntOp::And => Self::And,
-            IntOp::Or => Self::Or,
-            IntOp::Xor => Self::Xor,
+impl From<CmpKind> for mavros_int_semantics::CmpOp {
+    /// A true bijection, unlike the arithmetic conversion above: the model's `CmpOp` was given the
+    /// same three variants as [`CmpKind`] precisely so that it would be one.
+    fn from(kind: CmpKind) -> Self {
+        use mavros_int_semantics::CmpOp;
+        match kind {
+            CmpKind::Eq => CmpOp::Eq,
+            CmpKind::ULt => CmpOp::ULt,
+            CmpKind::SLt => CmpOp::SLt,
         }
     }
 }
 
 impl BinaryArithOpKind {
+    /// Every operation, so a new variant cannot be added without appearing here.
+    ///
+    /// The counterpart of `IntOp::ALL`, and the list a conformance sweep must drive from when it
+    /// is checking a *lowering*: the two vocabularies are not in bijection, so sweeping the model's
+    /// sixteen would cover only one of `UShl`/`SShl`.
+    pub const ALL: [BinaryArithOpKind; 17] = [
+        Self::UAdd,
+        Self::SAdd,
+        Self::USub,
+        Self::SSub,
+        Self::UMul,
+        Self::SMul,
+        Self::UDiv,
+        Self::SDiv,
+        Self::URem,
+        Self::SRem,
+        Self::UShl,
+        Self::SShl,
+        Self::UShr,
+        Self::SShr,
+        Self::And,
+        Self::Or,
+        Self::Xor,
+    ];
+
     /// This operation with its sign erased.
     pub fn group(self) -> ArithGroup {
         match self {
@@ -2399,15 +2430,18 @@ impl Blob {
 /// The value type stored in the high-level SSA's constants side-table.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Constant {
-    /// `bits` raw two's-complement bits, with **no reading attached**.
+    /// Raw two's-complement bits at a declared width, with **no reading attached**.
     ///
     /// There is no signed/unsigned pair here for the same reason [`TypeExpr::Int`] has no sign:
     /// nothing about a bit pattern says how to read it, and every consumer that cares takes the
     /// reading from the opcode applied to the value. That also makes interning exact — one pattern
     /// is one constant, so `u32 0xFFFFFFFE` and `i32 -2` are the same `ValueId`.
     ///
+    /// The width lives inside the [`IntBits`] rather than beside it, so there is no second copy of
+    /// it here that could disagree with the pattern's own normalisation.
+    ///
     /// [`TypeExpr::Int`]: crate::compiler::ssa::hlssa::TypeExpr::Int
-    Int(usize, u128),
+    Int(IntBits),
     // FIELD-ASSUMPTION: L2-ir-const
     Field(crate::compiler::Field),
     FnPtr(FunctionId),
@@ -2415,10 +2449,16 @@ pub enum Constant {
 }
 
 impl Constant {
+    /// A `bits`-wide integer constant carrying `value`, discarding any bits at or above `bits`.
+    #[must_use]
+    pub fn int(bits: usize, value: u128) -> Self {
+        Self::Int(IntBits::from_u128(bits, value))
+    }
+
     /// `true` if this is a scalar constant (not an aggregate `Blob`).
     pub fn is_scalar(&self) -> bool {
         match self {
-            Self::Int(_, _) | Self::Field(_) | Self::FnPtr(_) => true,
+            Self::Int(_) | Self::Field(_) | Self::FnPtr(_) => true,
             Self::Blob(_) => false,
         }
     }
@@ -2531,33 +2571,12 @@ pub enum Radix<V> {
 mod tests {
     use super::*;
 
-    /// Every operation, so a new variant cannot be added without appearing here.
-    const ALL_ARITH: [BinaryArithOpKind; 17] = [
-        BinaryArithOpKind::UAdd,
-        BinaryArithOpKind::SAdd,
-        BinaryArithOpKind::USub,
-        BinaryArithOpKind::SSub,
-        BinaryArithOpKind::UMul,
-        BinaryArithOpKind::SMul,
-        BinaryArithOpKind::UDiv,
-        BinaryArithOpKind::SDiv,
-        BinaryArithOpKind::URem,
-        BinaryArithOpKind::SRem,
-        BinaryArithOpKind::UShl,
-        BinaryArithOpKind::SShl,
-        BinaryArithOpKind::UShr,
-        BinaryArithOpKind::SShr,
-        BinaryArithOpKind::And,
-        BinaryArithOpKind::Or,
-        BinaryArithOpKind::Xor,
-    ];
-
     #[test]
     fn group_and_sign_reconstruct_the_operation() {
         // `with_sign` is the inverse of `(group, signedness)` on everything that has a sign, which
         // is what lets a consumer decompose an operation, decide on the sign separately, and put
         // it back together -- the shape the whole Stage-2 shim depends on.
-        for op in ALL_ARITH {
+        for op in BinaryArithOpKind::ALL {
             match op.signedness() {
                 Some(signed) => assert_eq!(BinaryArithOpKind::with_sign(op.group(), signed), op),
                 // The bitwise groups have one form, so both signs must land back on it.
@@ -2571,7 +2590,7 @@ mod tests {
 
     #[test]
     fn the_bitwise_operations_are_the_only_sign_free_ones() {
-        for op in ALL_ARITH {
+        for op in BinaryArithOpKind::ALL {
             let sign_free = op.signedness().is_none();
             assert_eq!(
                 sign_free,
@@ -2592,7 +2611,7 @@ mod tests {
         // `(group, signedness)` is the value-numbering key, so it has to be injective over the
         // opcode set: if two distinct operations ever answered the same pair, every value-numbering
         // site would merge them and the survivor's lowering would silently stand in for the other.
-        let mut keys: Vec<_> = ALL_ARITH
+        let mut keys: Vec<_> = BinaryArithOpKind::ALL
             .iter()
             .map(|op| (op.group(), op.signedness()))
             .collect();
@@ -2622,7 +2641,10 @@ mod tests {
         assert_eq!(CmpKind::Eq.symbol(), "==");
 
         // Every symbol is distinct, so a dump can be read back unambiguously.
-        let mut symbols: Vec<_> = ALL_ARITH.iter().map(|op| op.symbol()).collect();
+        let mut symbols: Vec<_> = BinaryArithOpKind::ALL
+            .iter()
+            .map(|op| op.symbol())
+            .collect();
         symbols.extend([CmpKind::ULt, CmpKind::SLt, CmpKind::Eq].map(|k| k.symbol()));
         let count = symbols.len();
         symbols.sort_unstable();

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -677,19 +677,13 @@ fn lower_constants_llssa(
 fn lower_constant_to_ll_constant(constant: &Constant) -> LLConstant {
     match constant {
         // Both tags hold the same raw pattern, and LLSSA has one `Int`, so one arm serves both.
-        Constant::Int(bits, val) => LLConstant::Int {
-            bits: *bits as u32,
-            value: *val,
-        },
+        Constant::Int(v) => LLConstant::Int(v.clone()),
         // FIELD-ASSUMPTION: L2-lower
         Constant::Field(fr) => {
             let values = fr
                 .montgomery_limbs()
                 .iter()
-                .map(|&limb| LLConstant::Int {
-                    bits: 64,
-                    value: limb as u128,
-                })
+                .map(|&limb| LLConstant::int(64, limb as u128))
                 .collect();
             LLConstant::Struct {
                 layout: LLStruct::field_elem(),
@@ -834,9 +828,8 @@ fn add_vm_parameter(func: &mut LLFunction, llssa: &mut LLSSA) -> ValueId {
 
 /// The LLSSA integer operation for an HLSSA arithmetic group read at a given signedness.
 ///
-/// This is the whole of what `hlssa_to_llssa` used to spell out twice, once per integer type
-/// variant — the two tables were identical apart from the three groups where the sign selects a
-/// different machine operation.
+/// One table rather than one per integer type variant: they differ only in the three groups where
+/// the sign selects a different machine operation, which is what the `signed` parameter carries.
 ///
 /// `Shl` has no signed form: a left shift is the same map on the bits either way, which is why
 /// HLSSA still distinguishes `UShl` from `SShl` (they differ in their overflow contract, not in
@@ -851,8 +844,8 @@ pub(crate) fn int_arith_op(group: ArithGroup, signed: bool) -> IntArithOp {
         ArithGroup::Xor => IntArithOp::Xor,
         ArithGroup::Shl => IntArithOp::Shl,
         // Arithmetic, not logical: Noir specifies sign-fill for a signed `>>`, and the cost
-        // interpreter (`instrumenter.rs`) has always agreed. This used to emit `UShr`, which made
-        // the backends disagree with both.
+        // interpreter (`instrumenter.rs`) agrees. Emitting `UShr` here would make the backends
+        // disagree with both.
         ArithGroup::Shr if signed => IntArithOp::AShr,
         ArithGroup::Shr => IntArithOp::UShr,
         ArithGroup::Div if signed => IntArithOp::SDiv,
@@ -2453,7 +2446,12 @@ fn lower_rc_drop(
 // =============================================================================
 
 /// Ensure a value is Field-sized ({i64, i64, i64, i64}).
+///
 /// Non-Field integer types are packed into raw little-endian limbs.
+///
+/// The `128` below is **this function's own cap and not the integer type system's**, which is why
+/// it is a literal rather than `MAX_SUPPORTED_UNSIGNED_BITS`: only two of the four limbs are ever
+/// filled here, so 128 bits is what the shape can carry whatever the type cap becomes.
 fn ensure_field_sized(
     e: &mut LLBlockEmitter<'_>,
     ll_val: ValueId,
@@ -2465,7 +2463,7 @@ fn ensure_field_sized(
     let (lo, hi) = match &source_type.expr {
         HLTypeExpr::Int(bits) if *bits < 64 => (e.zext(ll_val, 64), e.emit_int_const(64, 0)),
         HLTypeExpr::Int(64) => (ll_val, e.emit_int_const(64, 0)),
-        HLTypeExpr::Int(bits) if *bits <= MAX_SUPPORTED_UNSIGNED_BITS => {
+        HLTypeExpr::Int(bits) if *bits <= 128 => {
             let lo = e.truncate(ll_val, 64);
             let shift = e.emit_int_const(*bits as u32, 64);
             let hi = e.int_arith(IntArithOp::UShr, ll_val, shift);
@@ -4748,7 +4746,7 @@ mod tests {
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         // The immortal sentinel must be materialized and compared.
         assert!(
-            dump.contains("Int { bits: 64, value: 18446744073709551615 }"),
+            dump.contains("Int(64'hffffffffffffffff)"),
             "expected RC_IMMORTAL_OBJECT sentinel in dump:\n{dump}"
         );
         assert!(
@@ -4795,7 +4793,7 @@ mod tests {
         );
         // ...with four i64 limb values inside it.
         assert!(
-            dump.contains("Int { bits: 64"),
+            dump.contains("Int(64'h"),
             "expected i64 limb values in the struct constant:\n{dump}"
         );
         // ...and is NOT emitted as a runtime MkStruct instruction.
@@ -4861,9 +4859,9 @@ mod tests {
             let blob = e.emit_constant(HLConstant::Blob(HLBlob::new(
                 HLType::int(8),
                 vec![
-                    HLConstant::Int(8, 1),
-                    HLConstant::Int(8, 2),
-                    HLConstant::Int(8, 3),
+                    HLConstant::int(8, 1),
+                    HLConstant::int(8, 2),
+                    HLConstant::int(8, 3),
                 ],
             )));
             let arr = e.mk_seq_of_blob(HLType::int(8), blob);

--- a/compiler/src/compiler/ssa/llssa/builder.rs
+++ b/compiler/src/compiler/ssa/llssa/builder.rs
@@ -23,7 +23,7 @@ pub trait LLEmitter {
     }
 
     fn emit_int_const_u128(&mut self, bits: u32, value: u128) -> ValueId {
-        self.emit_constant(Constant::Int { bits, value })
+        self.emit_constant(Constant::int(bits, value))
     }
 
     fn emit_nullptr_const(&mut self) -> ValueId {

--- a/compiler/src/compiler/ssa/llssa/mod.rs
+++ b/compiler/src/compiler/ssa/llssa/mod.rs
@@ -7,6 +7,8 @@ use itertools::Itertools;
 use std::fmt::{self, Display, Formatter};
 use std::mem::size_of_val;
 
+use mavros_int_semantics::IntBits;
+
 use crate::compiler::ssa::{
     Block, Function, FunctionId, Instruction, Located, SSA, SSAConstants, ValueId,
 };
@@ -75,8 +77,11 @@ impl Blob {
 /// which pairs a struct layout with one constant value per field.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Constant {
-    /// A scalar integer constant of `bits` bits with the provided `value`.
-    Int { bits: u32, value: u128 },
+    /// A scalar integer constant, carrying its own width.
+    ///
+    /// The width lives inside the [`IntBits`] rather than beside it, so there is no second copy of
+    /// it here that could disagree with the pattern's own normalisation.
+    Int(IntBits),
 
     /// A null pointer constant.
     NullPtr,
@@ -89,13 +94,19 @@ pub enum Constant {
 }
 
 impl Constant {
+    /// A `bits`-wide integer constant carrying `value`, discarding any bits at or above `bits`.
+    #[must_use]
+    pub fn int(bits: u32, value: u128) -> Self {
+        Self::Int(IntBits::from_u128(bits as usize, value))
+    }
+
     /// True if this constant can legally fill a slot of `field` type.
     ///
     /// `InlineArray`/`FlexArray` fields are memory-only and have no constant form,
     /// so they never match; any other mismatched pairing is rejected too.
     pub fn matches_field(&self, field: &LLFieldType) -> bool {
         match (self, field) {
-            (Constant::Int { bits, .. }, LLFieldType::Int(w)) => bits == w,
+            (Constant::Int(v), LLFieldType::Int(w)) => v.bits() == *w as usize,
             (Constant::NullPtr, LLFieldType::Ptr) => true,
             (Constant::Struct { layout, values }, LLFieldType::Inline(inner)) => {
                 layout == inner && layout.accepts(values)
@@ -1221,9 +1232,7 @@ mod tests {
 
     #[test]
     fn accepts_matching_field_elem() {
-        let values: Vec<Constant> = (0..4)
-            .map(|v| Constant::Int { bits: 64, value: v })
-            .collect();
+        let values: Vec<Constant> = (0..4).map(|v| Constant::int(64, v)).collect();
         assert!(LLStruct::field_elem().accepts(&values));
     }
 
@@ -1232,17 +1241,15 @@ mod tests {
         let field_elem = LLStruct::field_elem();
 
         // Wrong arity: only three values for a four-field struct.
-        let three: Vec<Constant> = (0..3)
-            .map(|v| Constant::Int { bits: 64, value: v })
-            .collect();
+        let three: Vec<Constant> = (0..3).map(|v| Constant::int(64, v)).collect();
         assert!(!field_elem.accepts(&three));
 
         // Wrong int width: i32 where i64 is expected.
         let bad_width = vec![
-            Constant::Int { bits: 32, value: 0 },
-            Constant::Int { bits: 64, value: 0 },
-            Constant::Int { bits: 64, value: 0 },
-            Constant::Int { bits: 64, value: 0 },
+            Constant::int(32, 0),
+            Constant::int(64, 0),
+            Constant::int(64, 0),
+            Constant::int(64, 0),
         ];
         assert!(!field_elem.accepts(&bad_width));
 
@@ -1258,18 +1265,18 @@ mod tests {
         let outer = LLStruct::new(vec![LLFieldType::Inline(one_int.clone())]);
         let good_nested = vec![Constant::Struct {
             layout: one_int.clone(),
-            values: vec![Constant::Int { bits: 64, value: 7 }],
+            values: vec![Constant::int(64, 7)],
         }];
         assert!(outer.accepts(&good_nested));
         let bad_nested = vec![Constant::Struct {
             layout: LLStruct::new(vec![LLFieldType::Int(32)]),
-            values: vec![Constant::Int { bits: 32, value: 7 }],
+            values: vec![Constant::int(32, 7)],
         }];
         assert!(!outer.accepts(&bad_nested));
 
         // InlineArray / FlexArray fields have no constant form.
         let arr = LLStruct::new(vec![LLFieldType::InlineArray(one_int, 1)]);
-        assert!(!arr.accepts(&[Constant::Int { bits: 64, value: 0 }]));
+        assert!(!arr.accepts(&[Constant::int(64, 0)]));
     }
 
     #[test]
@@ -1283,9 +1290,9 @@ mod tests {
             let mut e = fb.test_block(entry);
             // Only three values for a four-limb field-element layout.
             let values = vec![
-                Constant::Int { bits: 64, value: 0 },
-                Constant::Int { bits: 64, value: 0 },
-                Constant::Int { bits: 64, value: 0 },
+                Constant::int(64, 0),
+                Constant::int(64, 0),
+                Constant::int(64, 0),
             ];
             e.emit_struct_const(LLStruct::field_elem(), values);
         });
@@ -1348,8 +1355,8 @@ mod tests {
 
         let dump = ssa.to_string(&DefaultSSAAnnotator);
         assert!(dump.contains("constants:"));
-        assert!(dump.contains("Int { bits: 64, value: 42 }"));
-        assert!(dump.contains("Int { bits: 64, value: 7 }"));
+        assert!(dump.contains("Int(64'h2a)"));
+        assert!(dump.contains("Int(64'h7)"));
         assert!(dump.contains("add"));
         assert!(dump.contains("return"));
     }

--- a/compiler/src/compiler/ssa/mod.rs
+++ b/compiler/src/compiler/ssa/mod.rs
@@ -1181,8 +1181,8 @@ mod tests {
     #[test]
     fn for_each_const_visits_all() {
         let ssa = HLSSA::with_main("main".to_string());
-        let a = ssa.add_const(Constant::Int(8, 1));
-        let b = ssa.add_const(Constant::Int(8, 2));
+        let a = ssa.add_const(Constant::int(8, 1));
+        let b = ssa.add_const(Constant::int(8, 2));
 
         let mut seen = HashMap::default();
         ssa.for_each_const(|vid, cv| {
@@ -1190,8 +1190,8 @@ mod tests {
         });
 
         assert_eq!(seen.len(), 2);
-        assert_eq!(seen.get(&a), Some(&Constant::Int(8, 1)));
-        assert_eq!(seen.get(&b), Some(&Constant::Int(8, 2)));
+        assert_eq!(seen.get(&a), Some(&Constant::int(8, 1)));
+        assert_eq!(seen.get(&b), Some(&Constant::int(8, 2)));
     }
 
     #[test]

--- a/compiler/src/compiler/util.rs
+++ b/compiler/src/compiler/util.rs
@@ -2,11 +2,53 @@
 
 use crate::compiler::ssa::hlssa::MAX_SUPPORTED_UNSIGNED_BITS;
 
-// The bit-pattern helpers are `mavros-int-semantics`', re-exported under the names the compiler has
-// always used for them.
-pub use mavros_int_semantics::{
-    decode_signed, encode_signed, fits_signed, mask as bit_mask, sign_extend as sign_extend_bits,
-};
+pub use mavros_int_semantics::mask as bit_mask;
+
+// The claim `FIELD_LIMB_BITS` is written on, checked rather than stated in prose.
+//
+// `ark_ff::BigInt<N>` is `[u64; N]`, so a canonical field representation's limb _count_ varies from
+// field to field while its limb _width_ does not. The limb _type_ is already pinned at every call
+// site, because `IntBits::from_field_limbs` takes a `&[u64]` and each caller hands it
+// `into_bigint().0`. What nothing else checks is that the model's 64 and arkworks' 64 are the same
+// number: if they ever parted, every field-sourced constant would be recombined with the wrong
+// place values and nothing would say so.
+//
+// It lives here because this is the lowest crate where both are in scope: `mavros-int-semantics`
+// cannot see `BigInt`, and must not, being the crate every evaluator is measured against.
+const _: () = assert!(
+    size_of::<ark_ff::BigInt<1>>() * 8 == mavros_int_semantics::int_bits::FIELD_LIMB_BITS,
+    "a canonical field limb is no longer FIELD_LIMB_BITS wide"
+);
+
+/// The host word an integer pattern carries, panicking above [`MAX_BITS`].
+///
+/// Its **production** callers are enumerated here and nowhere else (tests reach for it too, to read
+/// an answer back as a number):
+///
+/// - the `Int <-> Field` conversions (`hlssa_to_r1cs`'s `expect_in_u128` included, which comes the
+///   other way), which need a limbs-to-field path and so belong with the field-agnosticism work
+///   rather than here;
+/// - `spread_bits` / `unspread_bits`, whose own signatures are `u128`, and which Phase 5
+///   generalises along with the VM's fixed-width spread opcodes;
+/// - one genuine host-word arithmetic site, `instrumenter`'s `Radix::Dyn`, which uses the value as
+///   a `u128` divisor to build the digits of a radix decomposition.
+///
+/// Do not add a caller that could ask its question of the pattern instead: [`IntBits`] answers
+/// `is_zero` / `is_one` / `is_all_ones`, the bitwise and shift operations, `cast` / `bit_range` and
+/// the whole signed reading width-generically, and `usize::try_from` reads an index without the
+/// truncation an `as` cast would hide.
+///
+/// The width cap is 128, so the panic here is unreachable rather than merely unlikely.
+///
+/// [`IntBits`]: mavros_int_semantics::IntBits
+/// [`MAX_BITS`]: mavros_int_semantics::MAX_BITS
+///
+/// TODO Remove by the end of the `big-int-model` branch work
+#[track_caller]
+pub fn host_word(pattern: &mavros_int_semantics::IntBits) -> u128 {
+    u128::try_from(pattern)
+        .unwrap_or_else(|e| panic!("ICE: an integer constant is wider than the host: {e}"))
+}
 
 /// Panic with the canonical ICE for a tuple surviving past the `ElideTuples` pass.
 ///
@@ -96,50 +138,5 @@ pub mod test {
     pub fn falloc(e: &mut impl HLEmitter) -> ValueId {
         let init = e.field_const(fr(0));
         e.alloc(init)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn sign_extend_bits_agrees_with_decode_encode() {
-        // The authoritative definition of sign extension is "same integer, wider encoding".
-        // Check the bit-twiddling against it exhaustively for every 4-bit and 8-bit value.
-        for from in [4usize, 8] {
-            for raw in 0..(1u128 << from) {
-                for to in [from, from + 1, 16, 32, 64] {
-                    assert_eq!(
-                        sign_extend_bits(raw, from, to),
-                        encode_signed(to, decode_signed(from, raw)),
-                        "sign_extend_bits({raw}, {from}, {to})"
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn sign_extend_bits_is_identity_at_equal_width() {
-        for from in [1usize, 7, 8, 32] {
-            for raw in [0u128, 1, bit_mask(from), bit_mask(from) >> 1] {
-                assert_eq!(sign_extend_bits(raw, from, from), raw & bit_mask(from));
-            }
-        }
-    }
-
-    #[test]
-    fn sign_extend_bits_masks_its_input() {
-        // Bits above `from` are not part of the value and must not survive into the result.
-        assert_eq!(sign_extend_bits(0xFF00 | 0x01, 8, 16), 0x0001);
-        assert_eq!(sign_extend_bits(0xFF00 | 0x80, 8, 16), 0xFF80);
-    }
-
-    #[test]
-    fn sign_extend_bits_handles_full_width() {
-        // `to == 128` must not overflow the shift used to build the mask.
-        assert_eq!(sign_extend_bits(1, 1, 128), u128::MAX);
-        assert_eq!(sign_extend_bits(0, 1, 128), 0);
     }
 }

--- a/compiler/src/driver.rs
+++ b/compiler/src/driver.rs
@@ -890,7 +890,7 @@ fn const_contains_fn_ptr(constant: &Constant) -> bool {
     match constant {
         Constant::FnPtr(_) => true,
         Constant::Blob(blob) => blob.elements.iter().any(const_contains_fn_ptr),
-        Constant::Int(..) | Constant::Field(_) => false,
+        Constant::Int(_) | Constant::Field(_) => false,
     }
 }
 
@@ -1007,16 +1007,9 @@ mod tests {
         }
     }
 
-    /// The ABI keeps a [`Sign`] that the HLSSA type no longer has, so the two sides now disagree
-    /// about how many things an integer type _is_ -- two on one side, one on the other. That is
-    /// only safe while the sign makes no difference to the flattened width, which is what this
-    /// pins.
-    ///
-    /// It cannot fail today: `Type::int` takes no sign, so both rows below build the same value and
-    /// the assertion is a tautology on the HLSSA side. Its job is on the ABI side and in the
-    /// future -- `count_abi_type_elements` matches `AbiType::Integer { .. }` with the sign bound to
-    /// a wildcard, and a later reader who narrows that pattern to consult the sign would silently
-    /// resize the protected column block for exactly half of all integer parameters.
+    /// The ABI keeps a [`Sign`] that the HLSSA type does not have, so the two sides disagree about
+    /// how many things an integer type _is_ -- two on one side, one on the other. That is only safe
+    /// while the sign makes no difference to the flattened width, which is what this ensures.
     #[test]
     fn the_two_signs_flatten_to_the_same_width() {
         for width in [1u32, 8, 32, 64] {

--- a/docs/int-semantics.md
+++ b/docs/int-semantics.md
@@ -40,6 +40,10 @@ The rules themselves:
   and is arithmetic for a signed operand and logical for an unsigned one.
 - **A shift's amount is typed as the left operand's own type.** Noir's elaborator unifies the two,
   which is what makes checking the amount against `rhs_type.bit_size()` correct.
+- **An amount the guard IR failed to reject is reduced modulo the width**, not masked. The two
+  coincide at a power-of-two width. `reduced_shift_amount`, `vm::shift_amount` and
+  `llssa_to_llvm::reduce_shift_count` all reduce, which is what lets an integer be shifted at any
+  width rather than only a power of two.
 - **Casts** truncate the low bits when narrowing and sign-extend when widening a signed source.
   `iN as Field` is not a cast at all: the frontend rejects it with "Only unsigned integer types may
   be casted to Field".
@@ -61,8 +65,8 @@ total backend must still produce a bit pattern" are both crucial questions, but 
 potentially different answers.
 
 ```rust
-pub fn eval(op, sign, bits, lhs, rhs_bits, rhs) -> Outcome;      // Value(v) | Rejected(reason)
-pub fn residue(op, sign, bits, lhs, rhs_bits, rhs) -> Option<Raw>;
+pub fn eval(op: IntOp, lhs: &IntBits, rhs: &IntBits) -> Outcome; // Value(v) | Rejected(reason)
+pub fn residue(op: IntOp, lhs: &IntBits, rhs: &IntBits) -> Option<IntBits>;
 ```
 
 `eval` is **the Noir contract**: what an execution of this operation must do. Its four rejection
@@ -80,8 +84,17 @@ an evaluator that reaches such a point is entitled to treat it as a compiler bug
 The two are tied together inside the crate: `eval(p) == Value(v)` implies `residue(p) == Some(v)`.
 So conforming to `residue` on accepted inputs is conforming to Noir.
 
-`rhs_bits` is a separate parameter on purpose. A shift's amount can be declared narrower than the
-value it shifts, and an amount's own width is the only thing that says what its bit pattern means.
+Everything an operation needs is carried by the values it is given, which is why neither function
+takes a width or a signedness beside them. An `IntBits` is a `bits`-wide two's-complement pattern
+that knows its own width, so there is no width parameter for a caller to disagree with; and an
+`IntOp` names its own reading, so `UAdd` and `SAdd` are two operations rather than one operation and
+a flag. The reading is part of the operation because it changes the answer: `eval` rejects
+`200u8 + 100u8` and accepts the same two patterns read as `-56i8 + 100i8`.
+
+What remains is the rule that the operands must agree, and the model enforces it rather than
+assuming it: both operands must be one width for every operation except a shift. A shift's amount
+can legitimately be declared narrower than the value it shifts, and an amount's own width is the
+only thing that says what its bit pattern means.
 
 ## What We Check
 
@@ -160,8 +173,9 @@ Everywhere the intended semantics _has_ an opinion, this agrees with it.
 ### `vm`: the Bytecode Interpreter's Opcodes
 
 `vm/src/bytecode.rs`. This one does **not** delegate because it's a hot dispatch loop over `u64`
-cells with a separate `Int128` lane, while the model computes in `u128` throughout. Delegating would
-mean computing `eval` and discarding it which is not great for performance.
+cells with a separate `Int128` lane, while the model computes over heap-backed limbs. Delegating
+would mean an allocation per opcode to compute an `eval` that is then discarded, which is not great
+for performance.
 
 The relation is thus checked instead of enforced: **total, and equal to `residue` wherever the model
 specifies a pattern**. Total means no panic, no undefined behavior and no process abort — a witness
@@ -266,12 +280,15 @@ currently implement Noir.
 - **Signed integers wider than 64 bits are unsupported.** Noir has `i128`; mavros caps a signed
   reading at 64 bits and rejects the type outright.
 - **`u128 <<` is unsupported**, and panics rather than compiling.
-- **A shift at a non-power-of-two width would corrupt an in-range amount.** The amount mask is
-  `amount & (bits - 1)`, which is a modulo only where the width is a power of two; at `u3` an amount
-  of `1` masks to `0` in the VM and in the WASM backend while `hlssa_to_r1cs` shifts by `1`, so the
-  two halves of a proof would disagree. This is structurally unreachable rather than fixed — Noir
-  has no such width and `BitRange` keeps its source's type — and `shift_guard::shift_operand_bits`,
-  the single funnel both pure shift lowerings take their width from, asserts it stays that way.
+- **A _witness_ shift at a non-power-of-two width does not compile**, and panics rather than being
+  rejected. All three total evaluators reduce the amount modulo the width, so they agree at every
+  width and the gap is not a disagreement between backends; what is missing is the _guard IR_, and
+  only on the witness path. `witness_bitwise::lower_shift` indexes bit `log2(bits)` to test "too
+  large" and keys its `2^n` factor table by the same number, and both are the amount bound only
+  where the width is a power of two, so it asserts rather than emitting a check it cannot express.
+  The _pure_ path has no such limit: `shift_guard::emit_shift_amount_tests` builds a real
+  `amount < bits` comparison, which is width-agnostic, and `shift_guard::shift_operand_bits`
+  accordingly admits any width. Admitting a witness one means rebuilding its check the same way.
 - **A dead _witness_ `Add`/`Sub`/`Mul` loses its rejection.** DCE keeps the overflow check when it
   deletes a dead operation, but only when both operands are pure. The check a live witness operation
   gets is a range check on a field result rather than a comparison, and DCE cannot build that.

--- a/int-semantics/Cargo.toml
+++ b/int-semantics/Cargo.toml
@@ -3,9 +3,23 @@ name = "mavros-int-semantics"
 version.workspace = true
 edition.workspace = true
 
-# Deliberately dependency-free. This crate is the normative statement of what an integer operation
-# means, so it has to sit below every evaluator that must conform to it.
+# Two rules govern what may be added here, and "dependency-free" was only ever shorthand for them:
+# nothing may define what a Mavros integer operation answers, and nothing may sit above an evaluator
+# that has to conform to this crate.
+#
+# `thiserror` is derive-only, so it defines nothing at all.
+#
+# `num-bigint` supplies arithmetic on mathematical integers, which is the job the host's `u128` and
+# `i128` already do here. The normative content is the layer on top of that arithmetic — the
+# masking, the width rejection, the two's-complement reading, the shift-amount modulo — and none of
+# it moves into a dependency. Writing the bignum ourselves would instead make the crate every other
+# evaluator is measured against the least-scrutinised bignum in the tree, and would leave the model
+# with no oracle of its own; a widely-used one is an independent check on the arithmetic in a way
+# our own code cannot be. It is a leaf crate that knows nothing of Mavros, so it can be neither an
+# evaluator nor a cycle.
 [dependencies]
+num-bigint.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/int-semantics/src/corners.rs
+++ b/int-semantics/src/corners.rs
@@ -5,7 +5,9 @@
 //! is why this list is the backbone and `proptest` is the layer on top rather than the other way
 //! round.
 
-use crate::{MAX_BITS, MAX_SIGNED_BITS, Raw, mask};
+use std::sync::LazyLock;
+
+use crate::{MAX_BITS, MAX_SIGNED_BITS, mask};
 
 /// The widths every sweep covers.
 ///
@@ -24,25 +26,34 @@ pub const EXHAUSTIVE_WIDTHS: [usize; 3] = [1, 4, 8];
 
 /// Widths that are not powers of two.
 ///
-/// Kept separate because several evaluators quietly assume a power of two.
+/// Kept as a named set because they are the ones that catch a width assumption, and every
+/// evaluator sweep now chains them in: a mask by `bits - 1` passes at every width in [`WIDTHS`]
+/// and fails here.
 pub const ODD_WIDTHS: [usize; 3] = [3, 5, 7];
 
 /// Corner raw patterns for a `bits`-wide operand, deduplicated and masked to the width.
+///
+/// Deliberately host words rather than [`IntBits`](crate::IntBits) as these are a _corpus_, sorted
+/// and deduplicated, and a pattern has no ordering to sort by. The sweeps that use them are
+/// host-level evaluators too, so they build a pattern at the point they call the model and nowhere
+/// else.
 ///
 /// Covers, in both readings: zero and the small values, the unsigned top, the signed boundary pair
 /// and its neighbours, `-1` and `-2`, the powers of two that sit at the width's edges and middle,
 /// the two alternating patterns, and the two operands the existing corpus tests use for the case
 /// where the readings disagree.
 #[must_use]
-pub fn values(bits: usize) -> Vec<Raw> {
+pub fn values(bits: usize) -> Vec<u128> {
     assert!((1..=MAX_BITS).contains(&bits));
     let m = mask(bits);
     let mut out = vec![0, 1, 2, 3, m, m - 1];
 
     if bits >= 2 {
         let sign_bit = 1u128 << (bits - 1);
+
         // `MIN_S`, `MAX_S`, and one step inside each.
         out.extend([sign_bit, sign_bit - 1, sign_bit + 1, sign_bit - 2]);
+
         // `-1` is `m` (already present) and `-2` is one below it.
         out.push(m - 2);
     }
@@ -74,7 +85,7 @@ pub fn values(bits: usize) -> Vec<Raw> {
 /// those two. The host widths (63, 64, 65, 127, 128) are here because several evaluators reach for
 /// a `u64` or `u128` shift internally and inherit *its* masking rather than the operand's.
 #[must_use]
-pub fn shift_amounts(bits: usize, rhs_bits: usize) -> Vec<Raw> {
+pub fn shift_amounts(bits: usize, rhs_bits: usize) -> Vec<u128> {
     assert!((1..=MAX_BITS).contains(&bits) && (1..=MAX_BITS).contains(&rhs_bits));
     let m = mask(rhs_bits);
     let mut out = vec![0, 1, 63, 64, 65, 127, 128, m];
@@ -108,9 +119,8 @@ pub fn shift_amounts(bits: usize, rhs_bits: usize) -> Vec<Raw> {
 /// outright, because `assert_int_arith_widths` would panic on the IR one would have to come from.
 #[must_use]
 pub fn shift_width_pairs(signed: bool) -> Vec<(usize, usize)> {
-    let widths: &[usize] = if signed { &SIGNED_WIDTHS } else { &WIDTHS };
     let mut out = Vec::new();
-    for &bits in widths {
+    for &bits in widths_for(signed) {
         for &rhs_bits in &[bits, 8, 32, 64, MAX_BITS] {
             out.push((bits, rhs_bits));
         }
@@ -121,9 +131,32 @@ pub fn shift_width_pairs(signed: bool) -> Vec<(usize, usize)> {
 }
 
 /// The widths a sweep should use for `sign`.
+///
+/// This is [`WIDTHS`] (or [`SIGNED_WIDTHS`]) **plus [`ODD_WIDTHS`]**. The union lives here rather
+/// than in each sweep on purpose to avoid width assumptions.
+///
+/// Built once per reading rather than per call, and borrowed rather than cloned: every caller is a
+/// sweep that asks for this from inside a loop.
 #[must_use]
 pub fn widths_for(signed: bool) -> &'static [usize] {
-    if signed { &SIGNED_WIDTHS } else { &WIDTHS }
+    static UNSIGNED: LazyLock<Vec<usize>> = LazyLock::new(|| union_with_odd(false));
+    static SIGNED: LazyLock<Vec<usize>> = LazyLock::new(|| union_with_odd(true));
+
+    if signed { &SIGNED } else { &UNSIGNED }
+}
+
+/// The body of [`widths_for`], run once per reading.
+fn union_with_odd(signed: bool) -> Vec<usize> {
+    let base: &[usize] = if signed { &SIGNED_WIDTHS } else { &WIDTHS };
+    let mut out: Vec<usize> = base
+        .iter()
+        .copied()
+        .chain(ODD_WIDTHS)
+        .filter(|bits| !signed || signed_width_ok(*bits))
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    out
 }
 
 /// Assert a width is one a signed operation may use, mirroring the model's own bound.

--- a/int-semantics/src/corpus.rs
+++ b/int-semantics/src/corpus.rs
@@ -51,7 +51,7 @@
 //! the discharge that deletes a check outright.
 
 use crate::{
-    IntOp, MAX_BITS, MAX_SIGNED_BITS, Outcome, Raw, Reject, Sign, corners, decode_signed, eval,
+    IntBits, IntOp, MAX_BITS, MAX_SIGNED_BITS, Outcome, Reject, Sign, SignedValue, corners, eval,
     residue,
 };
 
@@ -117,12 +117,16 @@ impl GeneratedTest {
 }
 
 /// Every program whose operations this model _accepts_, one per operation.
-///
-/// One test per [`IntOp`] rather than per `(op, sign, width)`: the cells are cheap but the rows are
-/// not, and an operation is the granularity at which a red row is still self-explaining.
 #[must_use]
 pub fn accepting_tests() -> Vec<GeneratedTest> {
-    IntOp::ALL.iter().map(|&op| accepting_test(op)).collect()
+    let mut groups: Vec<Vec<IntOp>> = Vec::new();
+    for &op in &IntOp::ALL {
+        match groups.iter_mut().find(|g| g[0].name() == op.name()) {
+            Some(group) => group.push(op),
+            None => groups.push(vec![op]),
+        }
+    }
+    groups.iter().map(|ops| accepting_test(ops)).collect()
 }
 
 /// Every program this model _rejects_, one per `(operation, reading, reason)`.
@@ -134,7 +138,7 @@ pub fn accepting_tests() -> Vec<GeneratedTest> {
 pub fn rejecting_tests() -> Vec<GeneratedTest> {
     let mut out = Vec::new();
     for &op in &IntOp::ALL {
-        for sign in readings_for(op) {
+        for sign in renderings(op) {
             for reason in ALL_REASONS {
                 for case in Case::ALL {
                     if let Some(test) = rejecting_test(op, sign, reason, case) {
@@ -203,15 +207,17 @@ impl Case {
 // THE ACCEPTING CORPUS
 // ================================================================================================
 
-fn accepting_test(op: IntOp) -> GeneratedTest {
-    let cells: Vec<Cell> = readings_for(op)
-        .into_iter()
-        .flat_map(|sign| {
+fn accepting_test(ops: &[IntOp]) -> GeneratedTest {
+    let cells: Vec<Cell> = ops
+        .iter()
+        .flat_map(|&op| renderings(op).into_iter().map(move |sign| (op, sign)))
+        .flat_map(|(op, sign)| {
             widths_for(op, sign)
                 .into_iter()
                 .filter_map(move |bits| accepting_cell(op, sign, bits))
         })
         .collect();
+    let op = ops[0];
 
     let mut pool = Pool::default();
     for cell in &cells {
@@ -235,14 +241,14 @@ fn accepting_test(op: IntOp) -> GeneratedTest {
             body.push_str(&format!(
                 "    assert_eq({} {} {}, {});\n",
                 pool.name(cell.sign, cell.bits, lhs),
-                symbol(op),
+                op.symbol(),
                 pool.name(cell.sign, cell.bits, rhs),
                 literal(cell.sign, cell.bits, expected),
             ));
         }
     }
 
-    let name = format!("int_semantics_{}", op_name(op));
+    let name = format!("int_semantics_{}", op.name());
     let main_nr = format!(
         "{}fn main(\n{}) {{{}}}\n",
         accepting_header(op, &cells),
@@ -261,7 +267,7 @@ fn accepting_test(op: IntOp) -> GeneratedTest {
 /// The accepting `(lhs, rhs, expected)` triples for one `(op, sign, width)` cell.
 fn accepting_cell(op: IntOp, sign: Sign, bits: usize) -> Option<Cell> {
     let lhs_values = corners::values(bits);
-    let rhs_values = if is_shift(op) {
+    let rhs_values = if op.is_shift() {
         in_range_amounts(bits)
     } else {
         corners::values(bits)
@@ -270,8 +276,8 @@ fn accepting_cell(op: IntOp, sign: Sign, bits: usize) -> Option<Cell> {
     let mut accepted = Vec::new();
     for &lhs in &lhs_values {
         for &rhs in &rhs_values {
-            if let Outcome::Value(expected) = eval(op, sign, bits, lhs, bits, rhs) {
-                accepted.push((lhs, rhs, expected));
+            if let Outcome::Value(expected) = eval(op, &pattern(bits, lhs), &pattern(bits, rhs)) {
+                accepted.push((lhs, rhs, host(&expected)));
             }
         }
     }
@@ -292,7 +298,7 @@ fn accepting_cell(op: IntOp, sign: Sign, bits: usize) -> Option<Cell> {
 struct Cell {
     sign: Sign,
     bits: usize,
-    pairs: Vec<(Raw, Raw, Raw)>,
+    pairs: Vec<(u128, u128, u128)>,
 }
 
 // THE REJECTING CORPUS
@@ -304,12 +310,12 @@ fn rejecting_test(op: IntOp, sign: Sign, reason: Reject, case: Case) -> Option<G
     // The assertion is written against the answer a _total_ backend produces for this input, so
     // that removing the guard makes the program pass rather than fail. Where `residue` declines to
     // specify the answer there is nothing to assert -- see `sink` below.
-    let (checked, sink) = match residue(op, sign, bits, lhs, bits, rhs) {
+    let (checked, sink) = match residue(op, &pattern(bits, lhs), &pattern(bits, rhs)) {
         Some(expected) => (
             format!(
                 "    assert_eq(a {} b, {});\n",
-                symbol(op),
-                literal(sign, bits, expected)
+                op.symbol(),
+                literal(sign, bits, host(&expected))
             ),
             String::new(),
         ),
@@ -321,7 +327,7 @@ fn rejecting_test(op: IntOp, sign: Sign, reason: Reject, case: Case) -> Option<G
         None => (
             format!(
                 "    let r = a {} b;\n    assert_eq(r * zero, 0);\n",
-                symbol(op)
+                op.symbol()
             ),
             format!(", zero: {}", type_name(sign, bits)),
         ),
@@ -345,7 +351,7 @@ fn rejecting_test(op: IntOp, sign: Sign, reason: Reject, case: Case) -> Option<G
     Some(GeneratedTest {
         name: format!(
             "int_semantics_{}_{}_{}{}_fails",
-            op_name(op),
+            op.name(),
             reading_letter(sign),
             reason_name(reason),
             case.suffix()
@@ -356,8 +362,21 @@ fn rejecting_test(op: IntOp, sign: Sign, reason: Reject, case: Case) -> Option<G
     })
 }
 
+/// A `bits`-wide pattern from the host word this generator carries its values as.
+///
+/// The generator is host-typed throughout — it sorts, deduplicates and formats these as Noir
+/// literals — so an [`IntBits`] exists here only for the length of a call into the model.
+fn pattern(bits: usize, value: u128) -> IntBits {
+    IntBits::from_u128(bits, value)
+}
+
+/// The host word a model answer denotes, the other half of [`pattern`].
+fn host(value: &IntBits) -> u128 {
+    u128::try_from(value).expect("a pattern no wider than MAX_BITS fits a host word")
+}
+
 /// The operands one rejecting program is built from, or `None` where the case has no program.
-fn rejection_for(op: IntOp, sign: Sign, reason: Reject, case: Case) -> Option<(usize, Raw, Raw)> {
+fn rejection_for(op: IntOp, sign: Sign, reason: Reject, case: Case) -> Option<(usize, u128, u128)> {
     match case {
         Case::Narrowest => first_rejection(op, sign, reason),
         Case::Widest => widest_rejection(op, sign, reason),
@@ -371,7 +390,7 @@ fn rejection_for(op: IntOp, sign: Sign, reason: Reject, case: Case) -> Option<(u
 /// one whose check bound the width decides — see [`Case::Widest`] — and the width found has to
 /// differ from the narrowest one, since rendering the same program under two names would cost a
 /// row for nothing.
-fn widest_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, Raw, Raw)> {
+fn widest_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, u128, u128)> {
     if reason == Reject::DivByZero {
         return None;
     }
@@ -379,7 +398,7 @@ fn widest_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, Raw
     let narrowest = first_rejection(op, sign, reason)?.0;
     let mut widths = widths_for(op, sign);
     widths.reverse();
-    let (bits, lhs, rhs) = search_rejection(op, sign, reason, &widths)?;
+    let (bits, lhs, rhs) = search_rejection(op, reason, &widths)?;
     (bits != narrowest).then_some((bits, lhs, rhs))
 }
 
@@ -388,15 +407,15 @@ fn widest_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, Raw
 /// Only a signed shift has one: the reading is what makes an amount negative, and the width is
 /// pinned to the widest rather than searched for the reason [`Case::NegativeAmount`] gives. The
 /// amounts are filtered by their _reading_ rather than by magnitude.
-fn negative_amount_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, Raw, Raw)> {
-    if !(is_shift(op) && sign == Sign::Signed && reason == Reject::ShiftAmount) {
+fn negative_amount_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, u128, u128)> {
+    if !(op.is_shift() && sign == Sign::Signed && reason == Reject::ShiftAmount) {
         return None;
     }
 
     let bits = *widths_for(op, sign).last()?;
-    let amounts: Vec<Raw> = corners::shift_amounts(bits, bits)
+    let amounts: Vec<u128> = corners::shift_amounts(bits, bits)
         .into_iter()
-        .filter(|&a| decode_signed(bits, a) < 0)
+        .filter(|&a| pattern(bits, a).to_signed() < SignedValue::from(0u8))
         .collect();
 
     // Zero last, for the reason `first_rejection` gives.
@@ -405,7 +424,7 @@ fn negative_amount_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(u
 
     for &lhs in &lhs_values {
         for &rhs in &amounts {
-            if eval(op, sign, bits, lhs, bits, rhs) == Outcome::Rejected(reason) {
+            if eval(op, &pattern(bits, lhs), &pattern(bits, rhs)) == Outcome::Rejected(reason) {
                 return Some((bits, lhs, rhs));
             }
         }
@@ -418,22 +437,17 @@ fn negative_amount_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(u
 /// Searching rather than listing is the point: the corpus states which rejections the model has,
 /// so a `Reject` variant that gains or loses a reachable input changes the set of generated
 /// directories instead of drifting away from a hand-written list.
-fn first_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, Raw, Raw)> {
-    search_rejection(op, sign, reason, &widths_for(op, sign))
+fn first_rejection(op: IntOp, sign: Sign, reason: Reject) -> Option<(usize, u128, u128)> {
+    search_rejection(op, reason, &widths_for(op, sign))
 }
 
 /// The first corner pair rejected for `reason`, scanning `widths` in the order given.
 ///
 /// The order is the caller's whole contribution: [`first_rejection`] passes the widths ascending
 /// and [`widest_rejection`] descending, and neither has an opinion about anything else.
-fn search_rejection(
-    op: IntOp,
-    sign: Sign,
-    reason: Reject,
-    widths: &[usize],
-) -> Option<(usize, Raw, Raw)> {
+fn search_rejection(op: IntOp, reason: Reject, widths: &[usize]) -> Option<(usize, u128, u128)> {
     for &bits in widths {
-        let rhs_values = if is_shift(op) {
+        let rhs_values = if op.is_shift() {
             corners::shift_amounts(bits, bits)
         } else {
             corners::values(bits)
@@ -446,7 +460,7 @@ fn search_rejection(
         lhs_values.sort_by_key(|&v| v == 0);
         for &lhs in &lhs_values {
             for &rhs in &rhs_values {
-                if eval(op, sign, bits, lhs, bits, rhs) == Outcome::Rejected(reason) {
+                if eval(op, &pattern(bits, lhs), &pattern(bits, rhs)) == Outcome::Rejected(reason) {
                     return Some((bits, lhs, rhs));
                 }
             }
@@ -464,20 +478,20 @@ fn search_rejection(
 /// same corpus renders byte-identically however the cells that use them are ordered.
 #[derive(Default)]
 struct Pool {
-    used: BTreeSet<(usize, bool, Raw)>,
+    used: BTreeSet<(usize, bool, u128)>,
 }
 
 /// A pool with its parameter names decided, which is what the renderers actually read.
 struct NamedPool {
     /// Every group, in declaration order, as `(reading, width, values in reading order)`.
-    groups: Vec<(Sign, usize, Vec<Raw>)>,
+    groups: Vec<(Sign, usize, Vec<u128>)>,
 
     /// The parameter name each pooled value is declared under, keyed by `(width, signed, value)`.
-    names: BTreeMap<(usize, bool, Raw), String>,
+    names: BTreeMap<(usize, bool, u128), String>,
 }
 
 impl Pool {
-    fn record(&mut self, sign: Sign, bits: usize, value: Raw) {
+    fn record(&mut self, sign: Sign, bits: usize, value: u128) {
         self.used.insert((bits, sign == Sign::Signed, value));
     }
 
@@ -497,7 +511,7 @@ impl Pool {
         let mut names = BTreeMap::new();
         for (signed, bits) in keys {
             let sign = if signed { Sign::Signed } else { Sign::Unsigned };
-            let mut values: Vec<Raw> = self
+            let mut values: Vec<u128> = self
                 .used
                 .iter()
                 .filter(|&&(b, s, _)| b == bits && s == signed)
@@ -506,7 +520,7 @@ impl Pool {
             // Sorting signed values by their _reading_ rather than their pattern keeps the
             // generated `Prover.toml` monotonic, which is what makes it readable.
             if signed {
-                values.sort_by_key(|&v| decode_signed(bits, v));
+                values.sort_by_key(|&v| pattern(bits, v).to_signed());
             } else {
                 values.sort_unstable();
             }
@@ -524,7 +538,7 @@ impl Pool {
 }
 
 impl NamedPool {
-    fn name(&self, sign: Sign, bits: usize, value: Raw) -> &str {
+    fn name(&self, sign: Sign, bits: usize, value: u128) -> &str {
         self.names
             .get(&(bits, sign == Sign::Signed, value))
             .expect("ICE: a pair used a value the pool never recorded")
@@ -560,10 +574,10 @@ impl NamedPool {
 // ================================================================================================
 
 /// A `bits`-wide pattern as a Noir literal, under `sign`'s reading.
-fn literal(sign: Sign, bits: usize, value: Raw) -> String {
+fn literal(sign: Sign, bits: usize, value: u128) -> String {
     match sign {
         Sign::Unsigned => value.to_string(),
-        Sign::Signed => decode_signed(bits, value).to_string(),
+        Sign::Signed => pattern(bits, value).to_signed().to_string(),
     }
 }
 
@@ -586,36 +600,6 @@ const fn reading_word(sign: Sign) -> &'static str {
     }
 }
 
-const fn op_name(op: IntOp) -> &'static str {
-    match op {
-        IntOp::Add => "add",
-        IntOp::Sub => "sub",
-        IntOp::Mul => "mul",
-        IntOp::Div => "div",
-        IntOp::Rem => "rem",
-        IntOp::And => "and",
-        IntOp::Or => "or",
-        IntOp::Xor => "xor",
-        IntOp::Shl => "shl",
-        IntOp::Shr => "shr",
-    }
-}
-
-const fn symbol(op: IntOp) -> &'static str {
-    match op {
-        IntOp::Add => "+",
-        IntOp::Sub => "-",
-        IntOp::Mul => "*",
-        IntOp::Div => "/",
-        IntOp::Rem => "%",
-        IntOp::And => "&",
-        IntOp::Or => "|",
-        IntOp::Xor => "^",
-        IntOp::Shl => "<<",
-        IntOp::Shr => ">>",
-    }
-}
-
 const fn reason_name(reason: Reject) -> &'static str {
     match reason {
         Reject::Overflow => "overflow",
@@ -625,18 +609,21 @@ const fn reason_name(reason: Reject) -> &'static str {
     }
 }
 
-const fn is_shift(op: IntOp) -> bool {
-    matches!(op, IntOp::Shl | IntOp::Shr)
-}
-
-/// The readings worth generating for an operation.
+/// The Noir **types** worth declaring an operation's operands as.
 ///
-/// Both, even where the reading cannot change the answer -- `And`/`Or`/`Xor` -- the signed _type_
-/// takes its own route through the lowering, so it is worth a few pairs; how few is
-/// [`PAIRS_PER_READING_BLIND_CELL`]. A reading that has no rejecting input simply generates no
-/// rejecting test, which `first_rejection` decides rather than this.
-const fn readings_for(_op: IntOp) -> [Sign; 2] {
-    [Sign::Unsigned, Sign::Signed]
+/// A `Sign` here is a fact about the generated _source_, not about the model: it picks `u8` over
+/// `i8` in a signature and how a literal is spelled, which is all `Pool` and [`literal`] use it
+/// for.
+/// An operation names its own reading, so the type and the reading coincide wherever there is one.
+/// Where there is not, both types are worth generating anyway, because a signed _type_ takes its
+/// own route through the lowering even when the operation cannot tell the difference. How many
+/// pairs that is worth is [`PAIRS_PER_READING_BLIND_CELL`].
+///
+/// The result is twenty `(op, sign)` pairs: twelve operations that name a reading, once each, plus
+/// `And`/`Or`/`Xor`/`Shl` twice each.
+fn renderings(op: IntOp) -> Vec<Sign> {
+    op.sign()
+        .map_or_else(|| Sign::ALL.to_vec(), |sign| vec![sign])
 }
 
 /// The widths a generated program may use for `(op, sign)`.
@@ -660,10 +647,10 @@ fn widths_for(op: IntOp, sign: Sign) -> Vec<usize> {
 ///
 /// The corners are where the boundary bugs live: `bits - 1` is the largest legal amount and
 /// `bits / 2` sits where a decomposition changes shape.
-fn in_range_amounts(bits: usize) -> Vec<Raw> {
+fn in_range_amounts(bits: usize) -> Vec<u128> {
     corners::shift_amounts(bits, bits)
         .into_iter()
-        .filter(|&a| a < bits as Raw)
+        .filter(|&a| a < bits as u128)
         .collect()
 }
 
@@ -707,7 +694,7 @@ fn accepting_header(op: IntOp, cells: &[Cell]) -> String {
          // `assert_eq` then makes each answer observable to the R1CS-satisfaction oracle in every lane.\n\
          //\n\
          // Operation: `{}`. Cells, as (reading, width, pairs):\n",
-        symbol(op)
+        op.symbol()
     ));
     for cell in cells {
         out.push_str(&format!(
@@ -725,8 +712,8 @@ fn rejecting_header(
     op: IntOp,
     sign: Sign,
     bits: usize,
-    lhs: Raw,
-    rhs: Raw,
+    lhs: u128,
+    rhs: u128,
     reason: Reject,
     case: Case,
 ) -> String {
@@ -739,7 +726,7 @@ fn rejecting_header(
          // Both operands are witnesses, which is the half the hand-written `noir_failure_tests` do not\n\
          // cover: those put the operands behind a function so the *pure* check is under test, whereas\n\
          // here the check is owed by the witness lowering instead.\n",
-        symbol(op),
+        op.symbol(),
         reading_word(sign),
         bits,
         literal(sign, bits, lhs),
@@ -761,7 +748,7 @@ fn rejecting_header(
              // narrower width because the widening cast ahead of the bound test clears the sign bit.\n",
         );
     }
-    if residue(op, sign, bits, lhs, bits, rhs).is_some() {
+    if residue(op, &pattern(bits, lhs), &pattern(bits, rhs)).is_some() {
         out.push_str(
             "//\n// The assertion is written against the answer a total backend produces anyway, so removing\n\
              // the guard makes this program PASS -- which an expect-failure row reports as a failure.\n",
@@ -792,13 +779,13 @@ mod tests {
     fn every_expected_answer_is_the_models() {
         let mut checked = 0;
         for &op in &IntOp::ALL {
-            for sign in readings_for(op) {
+            for sign in renderings(op) {
                 for bits in widths_for(op, sign) {
                     let Some(cell) = accepting_cell(op, sign, bits) else { continue };
                     for (lhs, rhs, expected) in cell.pairs {
                         assert_eq!(
-                            eval(op, sign, bits, lhs, bits, rhs),
-                            Outcome::Value(expected),
+                            eval(op, &pattern(bits, lhs), &pattern(bits, rhs)),
+                            Outcome::Value(pattern(bits, expected)),
                             "{op:?} {sign:?} at {bits} bits: {lhs:#x} and {rhs:#x}"
                         );
                         checked += 1;
@@ -817,14 +804,14 @@ mod tests {
     #[test]
     fn every_rejecting_program_is_one_the_model_rejects() {
         for &op in &IntOp::ALL {
-            for sign in readings_for(op) {
+            for sign in renderings(op) {
                 for reason in ALL_REASONS {
                     for case in Case::ALL {
                         let Some((bits, lhs, rhs)) = rejection_for(op, sign, reason, case) else {
                             continue;
                         };
                         assert_eq!(
-                            eval(op, sign, bits, lhs, bits, rhs),
+                            eval(op, &pattern(bits, lhs), &pattern(bits, rhs)),
                             Outcome::Rejected(reason)
                         );
                     }
@@ -856,19 +843,22 @@ mod tests {
     /// back to having none with every row still green.
     #[test]
     fn the_negative_shift_amount_case_reaches_the_corpus() {
-        for op in [IntOp::Shl, IntOp::Shr] {
+        for op in [IntOp::Shl, IntOp::SShr] {
             let (bits, _, rhs) = negative_amount_rejection(op, Sign::Signed, Reject::ShiftAmount)
                 .unwrap_or_else(|| panic!("{op:?} generates no negative-amount program"));
             assert_eq!(
                 bits, MAX_SIGNED_BITS,
                 "the conjunct is dead below {MAX_SIGNED_BITS} bits"
             );
-            assert!(decode_signed(bits, rhs) < 0, "the amount is not negative");
+            assert!(
+                pattern(bits, rhs).to_signed() < SignedValue::from(0u8),
+                "the amount is not negative"
+            );
         }
 
         let names: Vec<String> = rejecting_tests().into_iter().map(|t| t.name).collect();
-        for op in [IntOp::Shl, IntOp::Shr] {
-            let want = format!("int_semantics_{}_i_amount_negative_fails", op_name(op));
+        for op in [IntOp::Shl, IntOp::SShr] {
+            let want = format!("int_semantics_{}_i_amount_negative_fails", op.name());
             assert!(names.contains(&want), "{want} was not generated");
         }
     }
@@ -894,7 +884,7 @@ mod tests {
     #[test]
     fn no_program_names_a_width_that_does_not_exist() {
         for &op in &IntOp::ALL {
-            for sign in readings_for(op) {
+            for sign in renderings(op) {
                 for bits in widths_for(op, sign) {
                     assert!(
                         NOIR_WIDTHS.contains(&bits),

--- a/int-semantics/src/int_bits.rs
+++ b/int-semantics/src/int_bits.rs
@@ -1,0 +1,1562 @@
+//! [`IntBits`] is a width-sized two's-complement bit pattern, used for storing and evaluating
+//! arbitrary-sized integers at compile time. It uses exactly [`IntBits::limbs_for_bits`] limbs with
+//! any additional bits set to zero.
+
+use std::fmt;
+
+use num_bigint::BigUint;
+use thiserror::Error;
+
+use crate::{CmpOp, MAX_BITS, MAX_SIGNED_BITS, SignedValue, check_widths, mask};
+
+// INTEGER BIT PATTERN
+// ================================================================================================
+
+/// A `bits`-wide two's-complement pattern: exactly [`IntBits::limbs_for_bits`] little-endian
+/// 64-bit limbs, with every bit at or above `bits` set to zero.
+///
+/// It has no [`Ord`] implementation because it is a raw bit interpretation and there are two valid
+/// readings of ordering for this type. [`IntBits::compare`] should be used to choose a reading.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct IntBits {
+    /// The width of the integer.
+    bits: usize,
+
+    /// Exactly `IntBits::limbs_for_bits(bits)` of them, little-endian, with the top limb masked.
+    limbs: Box<[u64]>,
+}
+
+// CONSTRUCTORS
+// ================================================================================================
+
+/// Constructors for the type, all of which perform normalization during construction.
+///
+/// **None of these caps the width at [`MAX_BITS`]** as that is the _model's_ bound on the
+/// operations it will evaluate, not the type's on the patterns it can hold. What does assert it is
+/// the field-limb group below — [`IntBits::from_packed_limbs`], [`IntBits::from_field_limbs`] and
+/// their companion predicate [`IntBits::field_limbs_fit`] — because those are reading a _field
+/// element_, which the model does own an opinion about.
+///
+/// The **lower** bound is a different matter and is enforced through [`IntBits::limbs_for_bits`]: a
+/// width of zero describes no pattern at all, so it panics rather than producing an empty one.
+/// Everything that takes a width downstream — [`IntBits::cast`], [`IntBits::bit_range`],
+/// [`IntBits::sign_extend`] — inherits that panic, and a caller holding a width it did not choose
+/// itself is the one that has to refuse first.
+impl IntBits {
+    /// Zero at `bits` wide.
+    #[must_use]
+    pub fn zero(bits: usize) -> Self {
+        Self::normalized(bits, vec![0; Self::limbs_for_bits(bits)])
+    }
+
+    /// A `bits`-wide pattern carrying `value`, discarding any bits at or above `bits`.
+    #[must_use]
+    pub fn from_u128(bits: usize, value: u128) -> Self {
+        let count = Self::limbs_for_bits(bits);
+        let mut limbs = vec![0u64; count];
+        limbs[0] = value as u64;
+        if count > 1 {
+            limbs[1] = (value >> 64) as u64;
+        }
+        Self::normalized(bits, limbs)
+    }
+
+    /// Every bit below `bits` set, and the companion of [`IntBits::is_all_ones`].
+    ///
+    /// Distinct from [`crate::mask`], which answers the same thing as a _host_ word and so stops
+    /// being expressible at a width the host has no corresponding type for.
+    #[must_use]
+    pub fn all_ones(bits: usize) -> Self {
+        Self::normalized(bits, vec![u64::MAX; Self::limbs_for_bits(bits)])
+    }
+
+    /// A `bits`-wide pattern from little-endian limbs, zero-extending a slice too short to fill the
+    /// width and truncating one too long for it.
+    #[must_use]
+    pub fn from_limbs(bits: usize, limbs: &[u64]) -> Self {
+        let count = Self::limbs_for_bits(bits);
+        let mut out = vec![0u64; count];
+        let taken = limbs.len().min(count);
+        out[..taken].copy_from_slice(&limbs[..taken]);
+        Self::normalized(bits, out)
+    }
+}
+
+// FIELD LIMB INTEROP
+// ================================================================================================
+
+/// The width of one limb of a **canonical field representation**.
+///
+/// This is not a property of any particular field: `ark_ff::BigInt<const N: usize>` is `[u64; N]`,
+/// so the limb _count_ `N` varies from field to field while the limb _width_ does not. That is
+/// **arkworks'** `BigInt` and not the `num-bigint` one this crate computes with, whose own digit
+/// width is `pub(crate)` and irrelevant here: [`IntBits::from_biguint`] reads a magnitude back
+/// through `iter_u64_digits`, which is a `u64` view of it however it is stored.
+///
+/// The claim is therefore about a type this crate deliberately cannot see, so it is held to
+/// arkworks one crate up, by a `const` assertion in the compiler's `util.rs`.
+pub const FIELD_LIMB_BITS: usize = 64;
+
+/// Reading a field element's limbs as a pattern, which needs no reading of its own: a canonical
+/// field representation is an unsigned magnitude, so only the truncation is in question.
+impl IntBits {
+    /// Recombine little-endian limbs of `limb_bits` each into a `bits`-wide pattern.
+    ///
+    /// The limb width is a parameter because Mavros has two unrelated kinds of limb, and conflating
+    /// them risks a bug: a canonical field representation is always [`FIELD_LIMB_BITS`] wide, while
+    /// the witness decompositions in `witness_bitwise` use a width that is _derived from the field
+    /// size_. Both are little-endian limb vectors and neither knows the other's width.
+    ///
+    /// Each limb is masked to `limb_bits` first, so a caller packing a narrow limb into a wider
+    /// container need not clear the space above it.
+    ///
+    /// # Panics
+    ///
+    /// If `limb_bits` is zero, which describes no representation at all, or if `bits` is outside
+    /// the model's range.
+    #[must_use]
+    pub fn from_packed_limbs(limbs: &[u64], limb_bits: usize, bits: usize) -> Self {
+        assert!(
+            (1..=MAX_BITS).contains(&bits),
+            "pattern width {bits} is outside 1..={MAX_BITS}"
+        );
+        assert!(limb_bits > 0, "a limb must be at least one bit wide");
+
+        // Limb `i` starts at bit `i * limb_bits`, so the ones from here up contribute nothing below
+        // `bits` and the final truncation would discard them anyway.
+        let usable = bits.div_ceil(limb_bits);
+        let limb_mask = mask(limb_bits);
+
+        let low = limbs
+            .iter()
+            .take(usable)
+            .enumerate()
+            .fold(BigUint::ZERO, |acc, (i, &limb)| {
+                acc | (BigUint::from(u128::from(limb) & limb_mask) << (i * limb_bits))
+            });
+
+        Self::from_biguint(bits, &low)
+    }
+
+    /// Read a field element's canonical little-endian limbs as a `bits`-wide pattern.
+    ///
+    /// The `Field -> Int` cast, and [`IntBits::from_packed_limbs`] at [`FIELD_LIMB_BITS`]. It takes
+    /// the low `bits` bits of the **canonical** representation, so a caller holding a **Montgomery
+    /// form must convert first**.
+    ///
+    /// The slice is unsized because the limb count is a property of the field. A slice shorter than
+    /// `bits` implies is not an error either: it simply describes a smaller element.
+    ///
+    /// # Panics
+    ///
+    /// If `bits` is outside the model's range, as [`IntBits::from_packed_limbs`] does.
+    #[must_use]
+    pub fn from_field_limbs(limbs: &[u64], bits: usize) -> Self {
+        assert!(
+            (1..=MAX_BITS).contains(&bits),
+            "pattern width {bits} is outside 1..={MAX_BITS}"
+        );
+
+        // Not routed through `from_packed_limbs`: at the host limb width the packed limbs already
+        // **are** the pattern's own little-endian words, so there's nothing to unpack. The
+        // congruence is enforced in tests.
+        Self::from_limbs(bits, limbs)
+    }
+
+    /// Whether a field element's canonical limbs are entirely inside a `bits`-wide pattern.
+    ///
+    /// The companion of [`IntBits::from_field_limbs`], which **truncates**: this is how a caller
+    /// asks whether the truncation would lose anything, so that it can refuse if needed.
+    ///
+    /// # Panics
+    ///
+    /// If `bits` is outside the model's range.
+    #[must_use]
+    pub fn field_limbs_fit(limbs: &[u64], bits: usize) -> bool {
+        assert!(
+            (1..=MAX_BITS).contains(&bits),
+            "pattern width {bits} is outside 1..={MAX_BITS}"
+        );
+
+        // Limbs below `whole` are covered outright. The one at `whole` is covered only up to
+        // `spare` bits, and where `spare` is zero that shift asks for the whole limb: at a width
+        // that ends on a limb boundary the limb above it is entirely outside.
+        let whole = bits / FIELD_LIMB_BITS;
+        let spare = bits % FIELD_LIMB_BITS;
+
+        limbs
+            .iter()
+            .enumerate()
+            .all(|(i, &limb)| match i.cmp(&whole) {
+                std::cmp::Ordering::Less => true,
+                std::cmp::Ordering::Equal => limb >> spare == 0,
+                std::cmp::Ordering::Greater => limb == 0,
+            })
+    }
+}
+
+// ACCESSORS
+// ================================================================================================
+
+/// Reading a pattern back out.
+impl IntBits {
+    /// The declared width.
+    #[must_use]
+    pub fn bits(&self) -> usize {
+        self.bits
+    }
+
+    /// The [`IntBits::limb_count`] limbs in little-endian order.
+    #[must_use]
+    pub fn limbs(&self) -> &[u64] {
+        &self.limbs
+    }
+
+    /// The number of 64-bit limbs a `bits`-wide pattern occupies.
+    ///
+    /// The host limb is 64 bits and that is fixed by the machine, not by the field: this is the
+    /// quantity `int_cell_count` reserves in a VM frame and `for_each_constant_word` emits. The
+    /// _field_ limb is a different and narrower thing, derived from the field's own width.
+    ///
+    /// # Panics
+    ///
+    /// On a width of zero, which describes no pattern at all.
+    #[must_use]
+    pub fn limbs_for_bits(bits: usize) -> usize {
+        assert!(bits > 0, "an integer pattern is at least one bit wide");
+        bits.div_ceil(64)
+    }
+
+    /// How many limbs this pattern occupies.
+    #[must_use]
+    pub fn limb_count(&self) -> usize {
+        self.limbs.len()
+    }
+
+    /// Whether every bit is zero.
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        self.limbs.iter().all(|&limb| limb == 0)
+    }
+
+    /// Whether this is the pattern `1`, with only the low bit set.
+    #[must_use]
+    pub fn is_one(&self) -> bool {
+        self.limbs[0] == 1 && self.limbs[1..].iter().all(|&limb| limb == 0)
+    }
+
+    /// Whether every bit below the width is set.
+    ///
+    /// Read as two's complement that is `-1`, but this only says the pattern is saturated at its
+    /// own width. It is a property of the limbs alone precisely _because_ the pattern is normalized
+    /// — the top limb's own maximum is [`top_limb_mask`].
+    #[must_use]
+    pub fn is_all_ones(&self) -> bool {
+        let top = self.limbs.len() - 1;
+        self.limbs[..top].iter().all(|&limb| limb == u64::MAX)
+            && self.limbs[top] == top_limb_mask(self.bits)
+    }
+
+    /// Bit `index`, counting from the least significant, or [`None`] at or above the width.
+    ///
+    /// [`None`] rather than `false`, because the two are not the same thing: a pattern has no bit
+    /// at or above its own width, and answering `false` there would make an out-of-range read
+    /// indistinguishable from a zero bit that is genuinely part of the value.
+    #[must_use]
+    pub fn bit(&self, index: usize) -> Option<bool> {
+        if index >= self.bits {
+            return None;
+        }
+        Some((self.limbs[index / 64] >> (index % 64)) & 1 == 1)
+    }
+}
+
+// PATTERN OPERATIONS
+// ================================================================================================
+
+/// Operations a pattern supports _without_ a reading being named.
+///
+/// Every one of them is a rearrangement of bits: the answer for a given input is the same whether
+/// the operands are meant as signed or unsigned.
+impl IntBits {
+    /// Bitwise `and` with another pattern of the same width.
+    ///
+    /// # Panics
+    ///
+    /// If the widths differ. Two patterns of different widths have no common bit positions to
+    /// combine, and every caller here has already checked that they agree.
+    #[must_use]
+    pub fn and(&self, other: &Self) -> Self {
+        self.zip_with(other, |a, b| a & b)
+    }
+
+    /// Bitwise `or` with another pattern of the same width.
+    ///
+    /// # Panics
+    ///
+    /// As [`IntBits::and`] does, if the widths differ.
+    #[must_use]
+    pub fn or(&self, other: &Self) -> Self {
+        self.zip_with(other, |a, b| a | b)
+    }
+
+    /// Bitwise `xor` with another pattern of the same width.
+    ///
+    /// # Panics
+    ///
+    /// As [`IntBits::and`] does, if the widths differ.
+    #[must_use]
+    pub fn xor(&self, other: &Self) -> Self {
+        self.zip_with(other, |a, b| a ^ b)
+    }
+
+    /// Every bit flipped, held to the width.
+    #[must_use]
+    pub fn complement(&self) -> Self {
+        Self::normalized(self.bits, self.limbs.iter().map(|limb| !limb).collect())
+    }
+
+    /// Reinterpret at a new width: truncate when narrowing, zero-extend when widening.
+    ///
+    /// # Panics
+    ///
+    /// On a `to_bits` of zero, which describes no pattern to reinterpret as.
+    #[must_use]
+    pub fn cast(&self, to_bits: usize) -> Self {
+        // A cast to the width already held is the identity, and it is the common case: both
+        // constant folders spell the `BitRange` transfer as `bit_range(..).cast(self.bits())`.
+        if to_bits == self.bits {
+            return self.clone();
+        }
+        Self::from_limbs(to_bits, &self.limbs)
+    }
+
+    /// Extract `width` bits starting at `offset`, right-aligned, akin to HLSSA's `BitRange`.
+    ///
+    /// The truncation primitive: `v.bit_range(0, n)` is the low `n` bits, and a logical `>>` by a
+    /// constant amount is `v.bit_range(k, v.bits() - k)`.
+    ///
+    /// There is no bound on `offset`, because a pattern shifted past its own width is empty where
+    /// a host word shifted past its own width is undefined. `width` is bounded below, though, for
+    /// the reason [`IntBits::cast`] is: an empty window is not a pattern.
+    ///
+    /// # Panics
+    ///
+    /// On a `width` of zero. HLSSA's `BitRange` refuses one too (`analysis::types` types it as an
+    /// error), so a folder handed one is looking at IR that does not type-check.
+    #[must_use]
+    pub fn bit_range(&self, offset: usize, width: usize) -> Self {
+        self.shifted_right(offset).cast(width)
+    }
+
+    /// The pattern moved `amount` places toward the most significant end, zero-filling behind it.
+    ///
+    /// Named for the movement rather than for `<<`, because an operation's shift carries additional
+    /// rules: at or above the width Noir rejects, and a total backend reduces the amount modulo the
+    /// width first. Here an amount at or above the width simply leaves nothing.
+    #[must_use]
+    pub fn shifted_left(&self, amount: usize) -> Self {
+        if amount >= self.bits {
+            return Self::zero(self.bits);
+        }
+        let (whole, part) = (amount / 64, amount % 64);
+        let mut out = vec![0u64; self.limbs.len()];
+        for (i, &limb) in self.limbs.iter().enumerate() {
+            let Some(target) = out.get_mut(i + whole) else {
+                break;
+            };
+            *target |= limb << part;
+            // A shift by a whole limb is `limb << 64`, which is undefined rather than zero, so the
+            // carry into the next limb is guarded rather than written as `limb >> (64 - part)`.
+            if part > 0
+                && let Some(next) = out.get_mut(i + whole + 1)
+            {
+                *next |= limb >> (64 - part);
+            }
+        }
+        Self::normalized(self.bits, out)
+    }
+
+    /// The pattern moved `amount` places toward the least significant end, zero-filling behind it.
+    #[must_use]
+    pub fn shifted_right(&self, amount: usize) -> Self {
+        if amount >= self.bits {
+            return Self::zero(self.bits);
+        }
+        let (whole, part) = (amount / 64, amount % 64);
+        let mut out = vec![0u64; self.limbs.len()];
+        for i in 0..self.limbs.len() {
+            let Some(&limb) = self.limbs.get(i + whole) else {
+                break;
+            };
+            out[i] |= limb >> part;
+            if part > 0
+                && let Some(&next) = self.limbs.get(i + whole + 1)
+            {
+                out[i] |= next << (64 - part);
+            }
+        }
+        Self::normalized(self.bits, out)
+    }
+
+    /// Combine two same-width patterns limb by limb.
+    ///
+    /// # Panics
+    ///
+    /// If the widths differ.
+    fn zip_with(&self, other: &Self, f: impl Fn(u64, u64) -> u64) -> Self {
+        assert_eq!(
+            self.bits, other.bits,
+            "a bitwise operation needs two patterns of one width"
+        );
+        Self::normalized(
+            self.bits,
+            self.limbs
+                .iter()
+                .zip(other.limbs.iter())
+                .map(|(&a, &b)| f(a, b))
+                .collect(),
+        )
+    }
+}
+
+// OPERATIONS THAT NAME A READING
+// ================================================================================================
+
+/// The operations that name a **reading** of a pattern.
+///
+/// The block above answers only what is true of the bits (`and`, `cast`, `bit_range`, the shifts)
+/// and the type deliberately has no [`Ord`], because two patterns have two orderings and it cannot
+/// pick one. Everything here picks a signedness, encoded in its name.
+impl IntBits {
+    /// Read this pattern as two's complement.
+    ///
+    /// # Panics
+    ///
+    /// If the pattern is wider than [`MAX_SIGNED_BITS`].
+    #[must_use]
+    pub fn to_signed(&self) -> SignedValue {
+        let bits = self.bits();
+        assert!(
+            (1..=MAX_SIGNED_BITS).contains(&bits),
+            "a signed reading of a {bits}-bit pattern is outside 1..={MAX_SIGNED_BITS}"
+        );
+        let magnitude = SignedValue::from(BigUint::from(self));
+        if self.bit(self.bits() - 1) == Some(true) {
+            magnitude - two_pow(self.bits())
+        } else {
+            magnitude
+        }
+    }
+
+    /// Encode a signed value as a `bits`-wide pattern.
+    ///
+    /// Total for any `v`, however far outside the width it sits: a value that does not fit is
+    /// reduced modulo `2^bits`, as required by [`residue`](crate::residue).
+    #[must_use]
+    pub fn from_signed(bits: usize, v: &SignedValue) -> Self {
+        // A [`SignedValue`]'s bitwise operators read a negative value as two's complement extended
+        // indefinitely: masking to `bits` takes the low `bits` of that and lands in `0..2^bits`
+        // whatever the sign and magnitude of `v`.
+        let masked = v & (two_pow(bits) - SignedValue::from(1u8));
+        Self::from_biguint(bits, masked.magnitude())
+    }
+
+    /// Whether `v` is representable in `bits`-bit two's complement.
+    ///
+    /// # Panics
+    ///
+    /// If `bits` is above [`MAX_SIGNED_BITS`].
+    #[must_use]
+    pub fn fits_signed(bits: usize, v: &SignedValue) -> bool {
+        assert!(
+            (1..=MAX_SIGNED_BITS).contains(&bits),
+            "a signed reading at {bits} bits is outside 1..={MAX_SIGNED_BITS}"
+        );
+        *v >= Self::signed_min(bits) && *v <= Self::signed_max(bits)
+    }
+
+    /// The largest value a `bits`-wide signed pattern represents.
+    ///
+    /// # Panics
+    ///
+    /// On a width of zero: `bits - 1` would wrap in a release build and ask for a two-power with
+    /// no memory to hold it.
+    #[must_use]
+    pub fn signed_max(bits: usize) -> SignedValue {
+        assert!(bits >= 1, "a signed reading needs at least a sign bit");
+        two_pow(bits - 1) - SignedValue::from(1u8)
+    }
+
+    /// The smallest value a `bits`-wide signed pattern represents.
+    ///
+    /// # Panics
+    ///
+    /// On a width of zero, for the reason [`IntBits::signed_max`] gives.
+    #[must_use]
+    pub fn signed_min(bits: usize) -> SignedValue {
+        assert!(bits >= 1, "a signed reading needs at least a sign bit");
+        -two_pow(bits - 1)
+    }
+
+    /// Widen from the pattern's width to `to` bits, replicating the sign bit.
+    ///
+    /// # Panics
+    ///
+    /// On a narrowing. The width extended _from_ needs no check of its own as it is the receiver's.
+    #[must_use]
+    pub fn sign_extend(&self, to: usize) -> Self {
+        let from = self.bits();
+        assert!(to >= from, "cannot sign-extend {from} to {to}");
+        let widened = self.cast(to);
+        if self.bit(from - 1) == Some(true) {
+            // The fill is every bit from `from` up to `to`. At `to == from` the shift moves the
+            // ones clean out of the width and leaves nothing, which is the right answer: there is
+            // no room above the sign bit to fill.
+            widened.or(&Self::all_ones(to).shifted_left(from))
+        } else {
+            widened
+        }
+    }
+
+    /// The amount this pattern actually shifts a `operand_bits`-wide value by, where the guard IR
+    /// failed to reject it.
+    ///
+    /// The receiver is the **amount** and the parameter is the width of the value being shifted: an
+    /// amount carries a width of its own and it is not the width the reduction is against.
+    ///
+    /// `amount % operand_bits`: a genuine **modulo at every width**, rather than a mask. At a
+    /// power-of-two width the two coincide, but at a width that is not a power of two they differ,
+    /// and a mask would be incorrect.
+    ///
+    /// # Panics
+    ///
+    /// On an `operand_bits` of zero. The VM's counterpart answers `0` there, because its width
+    /// arrives from a frame cell and a zero-width cell holds nothing; this one's arrives from the
+    /// operand [`eval`](crate::eval) was handed, whose width check has already held it at one bit
+    /// or more.
+    #[must_use]
+    pub fn reduced_shift_amount(&self, operand_bits: usize) -> u32 {
+        assert!(
+            operand_bits > 0,
+            "a shift amount reduces against a width of at least one bit"
+        );
+        let reduced = BigUint::from(self) % BigUint::from(operand_bits);
+        u32::try_from(&reduced).expect("a value below a supported width fits a u32")
+    }
+
+    /// Compare against another pattern of the same width, under the reading `op` names.
+    ///
+    /// Spelled `compare` rather than `cmp` because [`IntBits`] deliberately has no [`Ord`] for an
+    /// inherent `cmp` to shadow, but one answering a `bool` beside the `Ord::cmp` everyone knows
+    /// answers an [`Ordering`](std::cmp::Ordering) is a readability trap for no gain.
+    ///
+    /// # Panics
+    ///
+    /// As [`eval`](crate::eval) does, on invalid or unequal widths.
+    #[must_use]
+    pub fn compare(&self, op: CmpOp, rhs: &Self) -> bool {
+        check_widths(matches!(op, CmpOp::SLt), false, self.bits(), rhs.bits());
+        match op {
+            // Equality is the one comparison a pattern answers on its own: two patterns of one
+            // width are equal under either reading exactly when their bits are.
+            CmpOp::Eq => self == rhs,
+            CmpOp::SLt => self.to_signed() < rhs.to_signed(),
+            CmpOp::ULt => BigUint::from(self) < BigUint::from(rhs),
+        }
+    }
+}
+
+/// `2^n` as a [`SignedValue`]: the constant every two's-complement boundary above is built from.
+fn two_pow(n: usize) -> SignedValue {
+    SignedValue::from(1u8) << n
+}
+
+// INVARIANT
+// ================================================================================================
+
+/// The private machinery that establishes the width/limb agreement.
+impl IntBits {
+    /// Establish the invariant: clear every bit at or above `bits` in the top limb.
+    fn normalized(bits: usize, mut limbs: Vec<u64>) -> Self {
+        assert_eq!(
+            limbs.len(),
+            Self::limbs_for_bits(bits),
+            "a {bits}-bit pattern needs exactly {} limbs",
+            Self::limbs_for_bits(bits)
+        );
+        let top = limbs.len() - 1;
+        limbs[top] &= top_limb_mask(bits);
+        Self {
+            bits,
+            limbs: limbs.into_boxed_slice(),
+        }
+    }
+}
+
+// CONVERSIONS FROM HOST TYPES
+// ================================================================================================
+
+// These all take their widths and interpretations from the host type.
+
+impl From<u8> for IntBits {
+    /// An 8-bit pattern: the width comes from the host type, so there is nothing to pass.
+    fn from(value: u8) -> Self {
+        Self::from_u128(8, u128::from(value))
+    }
+}
+
+impl From<i8> for IntBits {
+    /// An 8-bit pattern holding `value` in two's complement, which at the host type's own width is
+    /// simply its bit pattern: `-1` is every bit set, `i8::MIN` is the sign bit alone.
+    fn from(value: i8) -> Self {
+        Self::from_u128(8, u128::from(value as u8))
+    }
+}
+
+impl From<u16> for IntBits {
+    /// A 16-bit pattern: the width comes from the host type, so there is nothing to pass.
+    fn from(value: u16) -> Self {
+        Self::from_u128(16, u128::from(value))
+    }
+}
+
+impl From<i16> for IntBits {
+    /// A 16-bit pattern holding `value` in two's complement, which at the host type's own width
+    /// is simply its bit pattern: `-1` is every bit set, `i16::MIN` is the sign bit alone.
+    fn from(value: i16) -> Self {
+        Self::from_u128(16, u128::from(value as u16))
+    }
+}
+
+impl From<u32> for IntBits {
+    /// A 32-bit pattern: the width comes from the host type, so there is nothing to pass.
+    fn from(value: u32) -> Self {
+        Self::from_u128(32, u128::from(value))
+    }
+}
+
+impl From<i32> for IntBits {
+    /// A 32-bit pattern holding `value` in two's complement, which at the host type's own width
+    /// is simply its bit pattern: `-1` is every bit set, `i32::MIN` is the sign bit alone.
+    fn from(value: i32) -> Self {
+        Self::from_u128(32, u128::from(value as u32))
+    }
+}
+
+impl From<u64> for IntBits {
+    /// A 64-bit pattern: the width comes from the host type, so there is nothing to pass.
+    fn from(value: u64) -> Self {
+        Self::from_u128(64, u128::from(value))
+    }
+}
+
+impl From<i64> for IntBits {
+    /// A 64-bit pattern holding `value` in two's complement, which at the host type's own width
+    /// is simply its bit pattern: `-1` is every bit set, `i64::MIN` is the sign bit alone.
+    fn from(value: i64) -> Self {
+        Self::from_u128(64, u128::from(value as u64))
+    }
+}
+
+// CONVERSIONS TO HOST TYPES
+// ================================================================================================
+
+/// Reading a pattern back out, refusing rather than truncating if it will not fit.
+///
+/// Deliberately unsigned targets only as this type contains a bit pattern, not a signed or unsigned
+/// interpretation.
+impl TryFrom<&IntBits> for u8 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: &IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_u128()?).map_err(|_| DoesNotFit { bits: value.bits })
+    }
+}
+
+impl TryFrom<IntBits> for u8 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl TryFrom<&IntBits> for u16 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: &IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_u128()?).map_err(|_| DoesNotFit { bits: value.bits })
+    }
+}
+
+impl TryFrom<IntBits> for u16 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl TryFrom<&IntBits> for u32 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: &IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_u128()?).map_err(|_| DoesNotFit { bits: value.bits })
+    }
+}
+
+impl TryFrom<IntBits> for u32 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl TryFrom<&IntBits> for u64 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: &IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_u128()?).map_err(|_| DoesNotFit { bits: value.bits })
+    }
+}
+
+impl TryFrom<IntBits> for u64 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+impl TryFrom<&IntBits> for u128 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: &IntBits) -> Result<Self, Self::Error> {
+        value.as_u128()
+    }
+}
+
+impl TryFrom<IntBits> for u128 {
+    type Error = DoesNotFit;
+
+    fn try_from(value: IntBits) -> Result<Self, Self::Error> {
+        value.as_u128()
+    }
+}
+
+/// The one target whose width is the _machine's_ rather than a fixed number of bits.
+impl TryFrom<&IntBits> for usize {
+    type Error = DoesNotFit;
+
+    fn try_from(value: &IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_u128()?).map_err(|_| DoesNotFit { bits: value.bits })
+    }
+}
+
+impl TryFrom<IntBits> for usize {
+    type Error = DoesNotFit;
+
+    fn try_from(value: IntBits) -> Result<Self, Self::Error> {
+        Self::try_from(&value)
+    }
+}
+
+/// The one conversion the [`TryFrom`] impls above are all written in terms of.
+///
+/// It is private, and deliberately: a `u128` is the widest host word, so every narrower target
+/// checks its own range against the value this produces rather than re-deriving one from the limbs.
+/// Widening past 128 bits will change this function and nothing else.
+impl IntBits {
+    /// The pattern as a `u128`, unsigned, or [`DoesNotFit`] if any bit above 127 is set.
+    fn as_u128(&self) -> Result<u128, DoesNotFit> {
+        if self.limbs.iter().skip(2).any(|&limb| limb != 0) {
+            return Err(DoesNotFit { bits: self.bits });
+        }
+        let lo = self.limbs.first().copied().unwrap_or(0);
+        let hi = self.limbs.get(1).copied().unwrap_or(0);
+        Ok(u128::from(lo) | (u128::from(hi) << 64))
+    }
+}
+
+// FORMATTING
+// ================================================================================================
+
+/// Verilog's sized-literal notation.
+///
+/// Hand-written rather than derived because a derived one prints the limb vector, which is
+/// unreadable at any width worth having this type for: `int16384` would be 256 decimal limbs.
+impl fmt::Debug for IntBits {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}'h", self.bits)?;
+
+        // Most significant limb first, and the digits have to read as one number rather than as a
+        // per-limb rendering. That takes both halves: everything below the leading limb is padded
+        // to its full sixteen digits, so a zero limb cannot swallow the magnitude above it, and the
+        // leading limb is the most significant _non-zero_ one, so a wide pattern holding a small
+        // value does not acquire a run of unnecessary zeroes.
+        let Some(top) = self.limbs.iter().rposition(|&limb| limb != 0) else {
+            // Every limb is zero, so there is no leading digit to find and the value is `0`.
+            return write!(f, "0");
+        };
+
+        write!(f, "{:x}", self.limbs[top])?;
+        for limb in self.limbs[..top].iter().rev() {
+            write!(f, "{limb:016x}")?;
+        }
+        Ok(())
+    }
+}
+
+// CONVERSIONS TO AND FROM A BIGNUM
+// ================================================================================================
+
+/// The width-free view of a pattern, for the arithmetic the model does on it.
+///
+/// Unlike the host conversions above this one cannot fail, and unlike them it is not a reading: a
+/// [`BigUint`] is the unsigned magnitude of the bits, which is what they are before anyone decides
+/// what they mean.
+impl From<&IntBits> for BigUint {
+    fn from(value: &IntBits) -> Self {
+        let bytes: Vec<u8> = value
+            .limbs
+            .iter()
+            .flat_map(|limb| limb.to_le_bytes())
+            .collect();
+        Self::from_bytes_le(&bytes)
+    }
+}
+
+impl From<IntBits> for BigUint {
+    fn from(value: IntBits) -> Self {
+        Self::from(&value)
+    }
+}
+
+/// The direction the [`From`] impls above cannot take, because it needs a width.
+///
+/// A [`BigUint`] is a magnitude and carries none, so coming back from one is a choice about how
+/// many bits to keep rather than a conversion, which is why it is a named constructor here and not
+/// a `From`.
+impl IntBits {
+    /// A `bits`-wide pattern carrying `value`, discarding any bits at or above `bits`.
+    ///
+    /// The counterpart of the [`BigUint`] conversion above, and the way an arithmetic result comes
+    /// back to being a pattern. It truncates rather than refusing, which is what makes it the
+    /// wrapping every total evaluator owes.
+    #[must_use]
+    pub fn from_biguint(bits: usize, value: &BigUint) -> Self {
+        let digits: Vec<u64> = value.iter_u64_digits().collect();
+        Self::from_limbs(bits, &digits)
+    }
+}
+
+// CONVERSION ERROR TYPE
+// ================================================================================================
+
+/// A pattern that will not fit the host type asked for, carrying the declared width.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[error("a {bits}-bit pattern does not fit the host type")]
+pub struct DoesNotFit {
+    /// The width of the pattern that would not convert.
+    pub bits: usize,
+}
+
+// UTILITY FUNCTIONS
+// ================================================================================================
+
+/// The mask the top limb of a `bits`-wide pattern carries.
+///
+/// A width that is a whole number of limbs has a full top limb; `bits % 64 == 0` is that case and
+/// not an empty one, which is why it cannot be written as `(1 << (bits % 64)) - 1`.
+const fn top_limb_mask(bits: usize) -> u64 {
+    match bits % 64 {
+        0 => u64::MAX,
+        rest => (1u64 << rest) - 1,
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use proptest::prelude::*;
+
+    use std::collections::BTreeSet;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    /// Widths worth constructing at, chosen for their top limbs.
+    ///
+    /// `16383` and `16384` are the pair that matters most and the reason both are here: `16384` is
+    /// exactly 256 limbs, so its top limb is full and every `bits % 64` special case vanishes,
+    /// while `16383` is the widest width whose top limb is partial. They occupy the same number of
+    /// limbs, so a test that carries only one of them is testing half the boundary.
+    const WIDTHS: &[usize] = &[
+        1, 2, 3, 7, 8, 63, 64, 65, 96, 127, 128, 129, 191, 192, 193, 1000, 16383, 16384,
+    ];
+
+    fn hash_of(v: &IntBits) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        v.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// The reference the round-trip is held to, for the widths a `u128` can express.
+    fn mask_u128(bits: usize) -> u128 {
+        if bits >= 128 {
+            u128::MAX
+        } else {
+            (1u128 << bits) - 1
+        }
+    }
+
+    #[test]
+    fn a_pattern_prints_as_one_sized_literal() {
+        assert_eq!(format!("{:?}", IntBits::from(42u64)), "64'h2a");
+        assert_eq!(format!("{:?}", IntBits::zero(1)), "1'h0");
+        assert_eq!(format!("{:?}", IntBits::from(-1i8)), "8'hff");
+
+        // Across a limb boundary the digits have to read as one number: the low limb is padded to
+        // its full sixteen digits, so a zero low limb cannot swallow the high limb's magnitude.
+        assert_eq!(
+            format!("{:?}", IntBits::from_u128(128, 1u128 << 64)),
+            "128'h10000000000000000"
+        );
+        assert_eq!(
+            format!("{:?}", IntBits::from_limbs(129, &[0, 0, 1])),
+            "129'h100000000000000000000000000000000"
+        );
+
+        // The other half of "reads as one number": a value that does not reach the top limb is
+        // written the way a number is, without the run of leading zeroes the limb vector holds. The
+        // width prefix is what says how much room there was.
+        assert_eq!(format!("{:?}", IntBits::from_u128(128, 1)), "128'h1");
+        assert_eq!(format!("{:?}", IntBits::from_u128(16384, 42)), "16384'h2a");
+
+        // Zero has no significant limb at all, at any width.
+        assert_eq!(format!("{:?}", IntBits::zero(128)), "128'h0");
+        assert_eq!(format!("{:?}", IntBits::zero(16384)), "16384'h0");
+
+        // And the rendering stays injective.
+        let mut rendered: Vec<(String, IntBits)> = Vec::new();
+        for &bits in WIDTHS {
+            for value in [0u128, 1, 2, 42, 1 << 64, u128::MAX] {
+                let v = IntBits::from_u128(bits, value);
+                let text = format!("{v:?}");
+                if let Some((_, other)) = rendered.iter().find(|(seen, _)| *seen == text) {
+                    assert_eq!(*other, v, "{text} is the rendering of two patterns");
+                }
+                rendered.push((text, v));
+            }
+        }
+    }
+
+    #[test]
+    fn a_pattern_occupies_one_limb_per_64_bits_of_its_width() {
+        for &bits in WIDTHS {
+            assert_eq!(
+                IntBits::zero(bits).limb_count(),
+                bits.div_ceil(64),
+                "at {bits} bits"
+            );
+        }
+        // The 16383/16384 pair shares a limb count and differs only in the top limb's mask, which
+        // is exactly why the count alone is not enough to pin the representation down.
+        assert_eq!(IntBits::zero(16383).limb_count(), 256);
+        assert_eq!(IntBits::zero(16384).limb_count(), 256);
+    }
+
+    #[test]
+    fn two_widths_sharing_a_limb_count_are_different_patterns() {
+        // The reason the width is stored rather than inferred. Both of these pairs occupy the same
+        // number of limbs and hold the same limbs, so a pattern that did not carry its own width
+        // could not tell them apart -- and `Eq` would have meant "one spelling per value per limb
+        // count" where the interning bimap needs "per width".
+        for &(narrow, wide) in &[(63usize, 64usize), (16383, 16384), (1, 64), (65, 128)] {
+            let a = IntBits::from_u128(narrow, 1);
+            let b = IntBits::from_u128(wide, 1);
+            assert_eq!(
+                a.limbs(),
+                b.limbs(),
+                "{narrow} and {wide} hold the same limbs"
+            );
+            assert_eq!(a.limb_count(), b.limb_count(), "and occupy the same count");
+            assert_ne!(a, b, "but {narrow} and {wide} are not the same pattern");
+        }
+    }
+
+    #[test]
+    fn the_stored_width_and_the_limb_count_always_agree() {
+        for &bits in WIDTHS {
+            let v = IntBits::from_u128(bits, 12345);
+            assert_eq!(v.bits(), bits);
+            assert_eq!(
+                v.limb_count(),
+                IntBits::limbs_for_bits(v.bits()),
+                "at {bits} bits"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_conversion_takes_its_width_from_the_host_type() {
+        for (got, want_bits) in [
+            (IntBits::from(1u8), 8),
+            (IntBits::from(1u16), 16),
+            (IntBits::from(1u32), 32),
+            (IntBits::from(1u64), 64),
+            (IntBits::from(1i8), 8),
+            (IntBits::from(1i16), 16),
+            (IntBits::from(1i32), 32),
+            (IntBits::from(1i64), 64),
+        ] {
+            assert_eq!(got.bits(), want_bits);
+            assert_eq!(u128::try_from(&got), Ok(1));
+        }
+    }
+
+    #[test]
+    fn a_negative_reads_back_as_the_pattern_it_is() {
+        // A pattern has no sign, so reading one out gives the unsigned reading of the bits and
+        // nothing else: `-1i8` went in, `255u8` comes back. Recovering `-1` means naming the
+        // reading, which is `to_signed`'s job and not a conversion's.
+        let minus_one = IntBits::from(-1i8);
+        assert_eq!(u8::try_from(&minus_one), Ok(255));
+        assert_eq!(u32::try_from(&minus_one), Ok(255));
+        assert_eq!(minus_one.to_signed(), crate::SignedValue::from(-1));
+    }
+
+    #[test]
+    fn a_value_that_will_not_fit_the_target_is_refused() {
+        // Too wide for the target, though it fits a `u128` perfectly well.
+        let big = IntBits::from(300u16);
+        assert_eq!(u8::try_from(&big), Err(DoesNotFit { bits: 16 }));
+        assert_eq!(u16::try_from(&big), Ok(300));
+
+        // A negative value has no unsigned reading at all.
+        assert_eq!(
+            u8::try_from(&IntBits::from(-1i16)),
+            Err(DoesNotFit { bits: 16 })
+        );
+
+        // And the width the error carries is the pattern's, which is the thing the call site
+        // cannot see for itself.
+        assert_eq!(
+            u64::try_from(&IntBits::from_limbs(256, &[0, 0, 0, 1])),
+            Err(DoesNotFit { bits: 256 })
+        );
+    }
+
+    #[test]
+    fn the_error_names_the_width_that_would_not_convert() {
+        // The width is the whole content of the message: the call site already knows which host
+        // type it asked for, and cannot see what it asked of.
+        let err = u8::try_from(&IntBits::from(300u16)).expect_err("300 does not fit a u8");
+        assert_eq!(
+            err.to_string(),
+            "a 16-bit pattern does not fit the host type"
+        );
+    }
+
+    #[test]
+    fn a_by_value_conversion_agrees_with_the_borrowed_one() {
+        let v = IntBits::from(-2i32);
+        assert_eq!(u32::try_from(v.clone()), u32::try_from(&v));
+        assert_eq!(u8::try_from(v.clone()), u8::try_from(&v));
+    }
+
+    #[test]
+    fn a_signed_host_constructor_stores_the_twos_complement_pattern() {
+        // `-1` is every bit set, at the width the name gives and no wider. What this actually
+        // catches is a lost sign or a wrong width -- _not_ an over-wide sign extension, which
+        // `from_u128` masks away, so `value as i128 as u128` here would be equally correct.
+        assert_eq!(IntBits::from(-1i8), IntBits::from(u8::MAX));
+        assert_eq!(IntBits::from(-1i16), IntBits::from(u16::MAX));
+        assert_eq!(IntBits::from(-1i32), IntBits::from(u32::MAX));
+        assert_eq!(IntBits::from(-1i64), IntBits::from(u64::MAX));
+
+        // `INT_MIN` is the sign bit alone.
+        assert_eq!(IntBits::from(i8::MIN), IntBits::from(1u8 << 7));
+        assert_eq!(IntBits::from(i16::MIN), IntBits::from(1u16 << 15));
+        assert_eq!(IntBits::from(i32::MIN), IntBits::from(1u32 << 31));
+        assert_eq!(IntBits::from(i64::MIN), IntBits::from(1u64 << 63));
+
+        // Spelled out as limbs too, so the assertion does not rest on `From<u8>` being right.
+        assert_eq!(IntBits::from(-1i8).limbs(), &[0xFF]);
+        assert_eq!(IntBits::from(-2i8).limbs(), &[0xFE]);
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one bit wide")]
+    fn a_zero_width_pattern_is_rejected() {
+        let _ = IntBits::zero(0);
+    }
+
+    #[test]
+    fn no_bit_at_or_above_the_width_survives_construction() {
+        for &bits in WIDTHS {
+            // All-ones in every limb the width reserves, which is the worst case for the mask.
+            let saturated = vec![u64::MAX; bits.div_ceil(64)];
+            let v = IntBits::from_limbs(bits, &saturated);
+
+            for i in 0..bits {
+                assert_eq!(v.bit(i), Some(true), "bit {i} of {bits} was cleared");
+            }
+
+            // Checked against the limbs directly, NOT through `bit`. `bit` answers `None` at or
+            // above the width whatever the limbs hold, so asking it here would prove nothing --
+            // the top limb could be entirely dirty and this test would still pass.
+            let top = v.limbs().last().expect("a width has at least one limb");
+            assert_eq!(
+                top & !top_limb_mask(bits),
+                0,
+                "the top limb of {bits} kept bits above the width"
+            );
+
+            // And `bit` does refuse to read there, which is the separate claim.
+            for i in bits..bits.div_ceil(64) * 64 {
+                assert_eq!(v.bit(i), None, "bit {i} is outside a {bits}-bit pattern");
+            }
+        }
+    }
+
+    #[test]
+    fn dirt_above_the_width_does_not_change_the_value() {
+        // The canonicity property, stated the way it actually gets violated: a caller hands over a
+        // word that some earlier step left dirty above the declared width, and the result must be
+        // indistinguishable from the clean one. Anything less splits one value into two
+        // `ValueId`s at the interning bimap.
+        for &bits in &[1usize, 3, 8, 63, 64, 65, 127, 128] {
+            let clean = IntBits::from_u128(bits, 1);
+            let dirty = IntBits::from_u128(bits, 1 | !mask_u128(bits));
+            assert_eq!(clean, dirty, "at {bits} bits");
+            assert_eq!(hash_of(&clean), hash_of(&dirty), "at {bits} bits");
+        }
+
+        // And through the wide door too, where `from_u128` cannot reach.
+        for &bits in &[129usize, 1000, 16383] {
+            let mut dirty = vec![0u64; bits.div_ceil(64)];
+            dirty[0] = 1;
+            *dirty.last_mut().expect("a width has at least one limb") = u64::MAX;
+            let mut clean = vec![0u64; bits.div_ceil(64)];
+            clean[0] = 1;
+            *clean.last_mut().expect("a width has at least one limb") = top_limb_mask(bits);
+            assert_eq!(
+                IntBits::from_limbs(bits, &dirty),
+                IntBits::from_limbs(bits, &clean),
+                "at {bits} bits"
+            );
+        }
+    }
+
+    #[test]
+    fn a_full_top_limb_is_not_masked_away() {
+        // `bits % 64 == 0` is the case a naive `(1 << (bits % 64)) - 1` turns into a zero mask,
+        // which would silently delete the entire top limb of every whole-limb width.
+        for &bits in &[64usize, 128, 192, 16384] {
+            let saturated = vec![u64::MAX; bits / 64];
+            let v = IntBits::from_limbs(bits, &saturated);
+            assert_eq!(
+                v.limbs().last(),
+                Some(&u64::MAX),
+                "the top limb of {bits} was masked"
+            );
+        }
+    }
+
+    #[test]
+    fn a_limb_slice_is_zero_extended_and_truncated_to_the_width() {
+        // Short: the missing limbs read as zero rather than as garbage.
+        let wide = IntBits::from_limbs(256, &[7]);
+        assert_eq!(wide.limbs(), &[7, 0, 0, 0]);
+
+        // Long: the limbs past the width go, on the same terms as bits past the width within a
+        // limb. Truncating rather than rejecting is what keeps this consistent with `from_u128`.
+        let narrow = IntBits::from_limbs(64, &[7, u64::MAX, u64::MAX]);
+        assert_eq!(narrow.limbs(), &[7]);
+    }
+
+    #[test]
+    fn the_field_read_is_the_packed_one_at_the_host_limb_width() {
+        // `from_field_limbs` takes the shortcut `from_packed_limbs` cannot: at the host limb width
+        // the packed limbs already are the pattern's own words. The two must answer alike, so we
+        // pin it here.
+        //
+        // The slice lengths straddle the width on purpose -- shorter, exact and longer -- because
+        // that is where the two spellings' truncation and zero-extension could part company.
+        for &bits in &[1usize, 8, 63, 64, 65, 96, 127, 128] {
+            for limbs in [
+                &[][..],
+                &[0][..],
+                &[7][..],
+                &[u64::MAX][..],
+                &[7, 1][..],
+                &[u64::MAX, u64::MAX][..],
+                &[0, 0, 1][..],
+                &[u64::MAX, u64::MAX, u64::MAX, u64::MAX][..],
+            ] {
+                assert_eq!(
+                    IntBits::from_field_limbs(limbs, bits),
+                    IntBits::from_packed_limbs(limbs, FIELD_LIMB_BITS, bits),
+                    "{limbs:?} at {bits} bits"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_value_round_trips_through_a_host_word_when_it_fits() {
+        for &bits in &[1usize, 3, 8, 63, 64, 65, 127, 128] {
+            for value in [0u128, 1, 2, 0x5555_5555_5555_5555, u128::MAX, u128::MAX - 1] {
+                assert_eq!(
+                    u128::try_from(&IntBits::from_u128(bits, value)),
+                    Ok(value & mask_u128(bits)),
+                    "{value:#x} at {bits} bits"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_value_too_wide_for_a_host_word_declines_rather_than_truncating() {
+        // The whole reason the conversion is fallible: a caller wanting a host word out of a
+        // pattern has to decide what a wider one means, and refusing is what makes it decide.
+        let mut limbs = vec![0u64; 4];
+        limbs[3] = 1;
+        assert!(u128::try_from(&IntBits::from_limbs(256, &limbs)).is_err());
+
+        // A wide *width* with a narrow *value* still fits, because the question is about the
+        // value and not about how much room it was given.
+        assert_eq!(u128::try_from(&IntBits::from_u128(16384, 5)), Ok(5));
+        assert_eq!(u128::try_from(&IntBits::zero(16384)), Ok(0));
+    }
+
+    #[test]
+    fn is_zero_and_bit_agree_with_the_limbs() {
+        assert!(IntBits::zero(16384).is_zero());
+        assert!(IntBits::from_u128(128, 0).is_zero());
+        assert!(!IntBits::from_u128(128, 1 << 100).is_zero());
+
+        // A one-bit width has exactly one bit to read, and nothing above it.
+        let one = IntBits::from_u128(1, 1);
+        assert_eq!(one.bit(0), Some(true));
+        assert_eq!(one.bit(1), None);
+        assert_eq!(one.bit(63), None);
+        // Reading far past the last limb is out of range, not a panic.
+        assert_eq!(one.bit(100_000), None);
+    }
+
+    #[test]
+    fn the_distinguished_patterns_are_recognised_at_every_width() {
+        for &bits in WIDTHS {
+            let zero = IntBits::zero(bits);
+            let one = IntBits::from_u128(bits, 1);
+            let limbs = vec![u64::MAX; IntBits::limbs_for_bits(bits)];
+            let all_ones = IntBits::from_limbs(bits, &limbs);
+
+            assert!(zero.is_zero() && !zero.is_one(), "zero at {bits}");
+            assert!(one.is_one() && !one.is_zero(), "one at {bits}");
+            assert!(all_ones.is_all_ones(), "all ones at {bits}");
+            assert!(!zero.is_all_ones(), "zero is not saturated at {bits}");
+
+            // At one bit these three patterns are two, not three, and the predicates have to say
+            // so rather than each claiming its own value.
+            assert_eq!(one.is_all_ones(), bits == 1, "one vs all ones at {bits}");
+            assert_eq!(all_ones.is_one(), bits == 1, "all ones vs one at {bits}");
+        }
+
+        // Saturation is per-width, so the same limbs are all-ones at one width and not at another.
+        assert!(IntBits::from_limbs(64, &[u64::MAX]).is_all_ones());
+        assert!(!IntBits::from_limbs(128, &[u64::MAX, 0]).is_all_ones());
+        // And it must read every limb, not just the top one.
+        assert!(!IntBits::from_limbs(128, &[0, u64::MAX]).is_all_ones());
+        // Likewise `is_one` has to look past the limb the one is in, or any value whose low limb
+        // happens to be 1 answers yes.
+        assert!(!IntBits::from_limbs(128, &[1, 1]).is_one());
+    }
+
+    #[test]
+    fn an_index_too_wide_for_the_machine_is_refused_rather_than_truncated() {
+        // The whole point of the `usize` conversion: a pattern carrying a value above the host's
+        // address width must not come back as some unrelated small number that passes a bounds
+        // check it should have failed.
+        let huge = IntBits::from_u128(128, (u64::MAX as u128) + 1);
+        assert_eq!(usize::try_from(&huge), Err(DoesNotFit { bits: 128 }));
+
+        assert_eq!(usize::try_from(&IntBits::from_u128(128, 7)), Ok(7));
+        assert_eq!(usize::try_from(IntBits::from(3u8)), Ok(3));
+    }
+
+    #[test]
+    fn distinct_values_at_one_width_stay_distinct() {
+        // The other half of canonicity: masking must not collapse values that differ below the
+        // width. A mask applied at the wrong width would show up here and nowhere else.
+        for &bits in &[3usize, 8, 64, 65, 128] {
+            let m = mask_u128(bits);
+            let values = [0u128, 1, 2, 3, m, m - 1, m ^ 1];
+
+            // A `Vec` and a linear scan rather than a set: `IntBits` has no `Ord` for a `BTreeSet`
+            // and a `HashSet` is disallowed workspace-wide for its iteration order. Seven values.
+            let mut seen: Vec<IntBits> = Vec::new();
+            for value in values {
+                let v = IntBits::from_u128(bits, value);
+                if !seen.contains(&v) {
+                    seen.push(v);
+                }
+            }
+
+            let distinct = values.iter().map(|v| v & m).collect::<BTreeSet<_>>().len();
+            assert_eq!(seen.len(), distinct, "at {bits} bits");
+        }
+    }
+
+    proptest! {
+        /// Canonicity over the whole space rather than the corners: one value at one width has
+        /// exactly one spelling, however it is reached.
+        #[test]
+        fn one_value_at_one_width_has_one_spelling(
+            width_index in 0..WIDTHS.len(),
+            value in any::<u128>(),
+            dirt in any::<u128>(),
+        ) {
+            let bits = WIDTHS[width_index];
+            let direct = IntBits::from_u128(bits, value);
+
+            // Reached again through the limb door, carrying arbitrary dirt above the width.
+            let mut limbs = direct.limbs().to_vec();
+            let top = limbs.len() - 1;
+            limbs[top] |= (dirt as u64) & !top_limb_mask(bits);
+            let indirect = IntBits::from_limbs(bits, &limbs);
+
+            prop_assert_eq!(&direct, &indirect);
+            prop_assert_eq!(hash_of(&direct), hash_of(&indirect));
+        }
+
+        /// Construction is idempotent: feeding a pattern's own limbs back in changes nothing.
+        #[test]
+        fn rebuilding_from_its_own_limbs_is_the_identity(
+            width_index in 0..WIDTHS.len(),
+            value in any::<u128>(),
+        ) {
+            let bits = WIDTHS[width_index];
+            let v = IntBits::from_u128(bits, value);
+            prop_assert_eq!(IntBits::from_limbs(bits, v.limbs()), v);
+        }
+
+        /// The bits a pattern reports are exactly the bits its limbs hold, and none above.
+        #[test]
+        fn every_bit_reads_back_from_the_limb_that_holds_it(
+            width_index in 0..WIDTHS.len(),
+            value in any::<u128>(),
+        ) {
+            let bits = WIDTHS[width_index];
+            let v = IntBits::from_u128(bits, value);
+            for i in 0..bits.min(128) {
+                let want = (value >> i) & 1 == 1;
+                prop_assert_eq!(v.bit(i), Some(want), "bit {} at {} bits", i, bits);
+            }
+            for i in bits..bits + 64 {
+                prop_assert_eq!(v.bit(i), None, "bit {} is outside {} bits", i, bits);
+            }
+        }
+    }
+
+    // PATTERN OPERATIONS
+    // --------------------------------------------------------------------------------------
+
+    /// Widths that straddle every limb boundary a 128-bit cap can reach: a sub-limb width, the two
+    /// either side of the first boundary, an odd one, and the two either side of the second.
+    const CORNERS: [usize; 8] = [1, 5, 63, 64, 65, 96, 127, 128];
+
+    /// The `u128` a pattern denotes, for holding the limb code to host semantics.
+    fn as_u128(v: &IntBits) -> u128 {
+        u128::try_from(v).expect("the corner widths all fit a u128")
+    }
+
+    #[test]
+    fn all_ones_saturates_exactly_the_declared_width() {
+        for bits in CORNERS {
+            let ones = IntBits::all_ones(bits);
+            assert!(ones.is_all_ones(), "{bits}");
+            assert_eq!(ones.bit(bits - 1), Some(true), "{bits}");
+            assert_eq!(ones.bit(bits), None, "{bits} has no bit at its own width");
+            assert!(ones.complement().is_zero(), "{bits}");
+            assert_eq!(as_u128(&ones), crate::mask(bits), "{bits}");
+        }
+    }
+
+    #[test]
+    fn the_bitwise_operations_are_limbwise_across_a_boundary() {
+        // Values chosen so that both limbs differ and the top limb is partial at the odd widths,
+        // which is where a mask applied to the wrong limb would show.
+        for bits in CORNERS {
+            let a = IntBits::from_u128(bits, 0x0F0F_0F0F_0F0F_0F0F_FFFF_0000_FFFF_0000);
+            let b = IntBits::from_u128(bits, 0x00FF_00FF_00FF_00FF_0F0F_0F0F_0F0F_0F0F);
+            let (x, y) = (as_u128(&a), as_u128(&b));
+            assert_eq!(as_u128(&a.and(&b)), x & y, "and at {bits}");
+            assert_eq!(
+                as_u128(&a.or(&b)),
+                (x | y) & crate::mask(bits),
+                "or at {bits}"
+            );
+            assert_eq!(
+                as_u128(&a.xor(&b)),
+                (x ^ y) & crate::mask(bits),
+                "xor at {bits}"
+            );
+            assert_eq!(
+                as_u128(&a.complement()),
+                !x & crate::mask(bits),
+                "complement at {bits}"
+            );
+            assert_eq!(a.complement().complement(), a, "an involution at {bits}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot sign-extend 32 to 8")]
+    fn sign_extension_refuses_to_narrow() {
+        // The gate is a full `assert!` rather than a `debug_assert!` because a release build that
+        // skipped it would not merely truncate: the fill is taken from the source's sign bit, so a
+        // narrowing would answer a value that is neither the source nor its low bits.
+        let _ = IntBits::from(-1i32).sign_extend(8);
+    }
+
+    #[test]
+    #[should_panic(expected = "is outside 1..=64")]
+    fn a_signed_reading_refuses_a_pattern_above_the_signed_cap() {
+        // A caller that reaches here has skipped `assert_signed_op_width`, and answering would
+        // be worse than stopping.
+        let _ = IntBits::from_u128(128, 1).to_signed();
+    }
+
+    #[test]
+    #[should_panic(expected = "at least a sign bit")]
+    fn the_signed_bounds_refuse_a_zero_width() {
+        // `bits - 1` wraps in a release build, so this gate is the difference between a panic and
+        // asking for a two-power of `usize::MAX`.
+        let _ = IntBits::signed_max(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "a width of at least one bit")]
+    fn a_shift_amount_refuses_to_reduce_against_no_width() {
+        // The last width-taking method to answer instead of refusing. The VM's counterpart is total
+        // there because its width comes off a frame cell; this one's comes off the operand `eval`
+        // was handed, so a zero is a caller that skipped the model's own width check.
+        let _ = IntBits::from(1u8).reduced_shift_amount(0);
+    }
+
+    #[test]
+    fn a_shift_amount_reduces_by_the_width_it_is_given() {
+        // The neighboring claim, so the refusal above is not the only thing pinning this method: an
+        // in-range amount survives and an out-of-range one wraps by a modulo rather than a mask. At
+        // seven bits a mask by `bits - 1 == 6` would answer `0` for both of the first two.
+        assert_eq!(IntBits::from(1u8).reduced_shift_amount(7), 1);
+        assert_eq!(IntBits::from(8u8).reduced_shift_amount(7), 1);
+        assert_eq!(IntBits::from(9u8).reduced_shift_amount(8), 1);
+        assert_eq!(IntBits::from(1u8).reduced_shift_amount(1), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "two patterns of one width")]
+    fn a_bitwise_operation_refuses_two_widths() {
+        // 32 and 64 share a limb, so nothing about the storage stops this: it is refused because
+        // the bit positions of two widths do not correspond, not because the limbs disagree.
+        let _ = IntBits::from(1u32).and(&IntBits::from(1u64));
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one bit wide")]
+    fn a_cast_to_no_width_is_refused() {
+        // The width-taking operations inherit the constructors' lower bound rather than answering
+        // an empty pattern.
+        let _ = IntBits::from(1u8).cast(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one bit wide")]
+    fn an_empty_bit_range_is_refused() {
+        let _ = IntBits::from(0xABCDu16).bit_range(4, 0);
+    }
+
+    #[test]
+    fn a_cast_to_the_width_already_held_is_the_identity() {
+        // The fast path, and the property it has to preserve: `bit_range(..).cast(self.bits())` is
+        // how both constant folders spell the `BitRange` transfer, so the common case must answer
+        // exactly what the general one does.
+        for bits in CORNERS {
+            for value in [0u128, 1, 0x5A5A_5A5A, u128::MAX] {
+                let v = IntBits::from_u128(bits, value);
+                assert_eq!(v.cast(bits), v, "{value:#x} at {bits} bits");
+                assert_eq!(v.cast(bits), IntBits::from_limbs(bits, v.limbs()));
+            }
+        }
+    }
+
+    #[test]
+    fn shifting_moves_bits_and_discards_what_leaves_the_width() {
+        for bits in CORNERS {
+            let v = IntBits::from_u128(bits, 0x1234_5678_9ABC_DEF0_0FED_CBA9_8765_4321);
+            let x = as_u128(&v);
+            for amount in [0usize, 1, 31, 63, 64, 65, 96, 127] {
+                let expected_left = x.checked_shl(amount as u32).unwrap_or(0) & crate::mask(bits);
+                let expected_right = x.checked_shr(amount as u32).unwrap_or(0);
+                assert_eq!(
+                    as_u128(&v.shifted_left(amount)),
+                    if amount >= bits { 0 } else { expected_left },
+                    "{bits} << {amount}"
+                );
+                assert_eq!(
+                    as_u128(&v.shifted_right(amount)),
+                    if amount >= bits { 0 } else { expected_right },
+                    "{bits} >> {amount}"
+                );
+            }
+            assert_eq!(v.shifted_left(0), v, "{bits}");
+            assert_eq!(v.shifted_right(0), v, "{bits}");
+        }
+    }
+
+    #[test]
+    fn a_shift_by_a_whole_limb_keeps_every_bit_it_should() {
+        // The case the guarded carry exists for: `limb << 64` is undefined rather than zero, so a
+        // shift that is an exact multiple of the limb width must take the other path.
+        let v = IntBits::from_u128(128, u128::MAX);
+        assert_eq!(as_u128(&v.shifted_left(64)), u128::MAX << 64);
+        assert_eq!(as_u128(&v.shifted_right(64)), u128::MAX >> 64);
+    }
+
+    // BIGNUM CONVERSIONS
+    // --------------------------------------------------------------------------------------
+
+    #[test]
+    fn a_pattern_round_trips_through_a_bignum() {
+        for bits in CORNERS {
+            for value in [0u128, 1, 0xDEAD_BEEF, u128::MAX, u128::MAX >> 1] {
+                let v = IntBits::from_u128(bits, value);
+                let big = BigUint::from(&v);
+                assert_eq!(
+                    big,
+                    BigUint::from(as_u128(&v)),
+                    "the magnitude at {bits} of {value:#x}"
+                );
+                assert_eq!(IntBits::from_biguint(bits, &big), v, "{bits}, {value:#x}");
+            }
+        }
+    }
+
+    #[test]
+    fn a_bignum_too_wide_for_the_pattern_is_truncated() {
+        // The same discipline as `from_limbs`: a constructor that takes a width discards above it
+        // rather than complaining, which is what makes it the wrapping a total evaluator owes.
+        let wide = BigUint::from(u128::MAX);
+        assert_eq!(IntBits::from_biguint(8, &wide), IntBits::from(0xFFu8));
+        assert_eq!(IntBits::from_biguint(64, &wide), IntBits::from(u64::MAX));
+    }
+}

--- a/int-semantics/src/lib.rs
+++ b/int-semantics/src/lib.rs
@@ -17,41 +17,45 @@
 //! The two are tied together by the invariant that **an accepted evaluation and its residue never disagree**.
 //!
 //! ```
-//! # use mavros_int_semantics::{eval, residue, IntOp, Outcome, Sign};
+//! # use mavros_int_semantics::{eval, residue, IntBits, IntOp, Outcome};
+//! let u8 = |v| IntBits::from_u128(8, v);
+//!
 //! // Accepted, so both agree.
-//! assert_eq!(
-//!     eval(IntOp::Add, Sign::Unsigned, 8, 1, 8, 2),
-//!     Outcome::Value(3)
-//! );
-//! assert_eq!(residue(IntOp::Add, Sign::Unsigned, 8, 1, 8, 2), Some(3));
+//! assert_eq!(eval(IntOp::UAdd, &u8(1), &u8(2)), Outcome::Value(u8(3)));
+//! assert_eq!(residue(IntOp::UAdd, &u8(1), &u8(2)), Some(u8(3)));
 //!
 //! // Rejected by Noir, but every backend wraps, so the residue is pinned.
 //! assert!(matches!(
-//!     eval(IntOp::Add, Sign::Unsigned, 8, 200, 8, 100),
+//!     eval(IntOp::UAdd, &u8(200), &u8(100)),
 //!     Outcome::Rejected(_)
 //! ));
+//! assert_eq!(residue(IntOp::UAdd, &u8(200), &u8(100)), Some(u8(44)));
+//!
+//! // The same two patterns read as signed are `-56 + 100`, which fits. The operation is what
+//! // picks the reading, so these are two operations rather than one with a flag.
 //! assert_eq!(
-//!     residue(IntOp::Add, Sign::Unsigned, 8, 200, 8, 100),
-//!     Some(44)
+//!     eval(IntOp::SAdd, &u8(200), &u8(100)),
+//!     Outcome::Value(u8(44))
 //! );
 //!
 //! // Rejected, and the backends do not agree on what to do anyway.
 //! assert!(matches!(
-//!     eval(IntOp::Div, Sign::Unsigned, 8, 1, 8, 0),
+//!     eval(IntOp::UDiv, &u8(1), &u8(0)),
 //!     Outcome::Rejected(_)
 //! ));
-//! assert_eq!(residue(IntOp::Div, Sign::Unsigned, 8, 1, 8, 0), None);
+//! assert_eq!(residue(IntOp::UDiv, &u8(1), &u8(0)), None);
 //! ```
 //!
-//! # Values are Raw
+//! # Values are Patterns
 //!
-//! Every value in and out is a **raw bit pattern** masked to its width, never a signed integer. The
-//! value carries no sign, so it is up to the _operation_ to enforce interpretation instead.
+//! Every value in and out is an [`IntBits`], which is a **raw bit pattern** that carries its own
+//! width. With no sign, it's up to the operation to name the reading much like in the SSA, and its
+//! corresponding 2's-complement reading is [`SignedValue`].
 //!
-//! That pattern is spelled [`Raw`] rather than `u128`, and its two's-complement reading is spelled
-//! [`SignedValue`] rather than `i128`, so that the host types stay an implementation detail of this
-//! crate rather than something every conformance test and delegating folder has written into its
-//! own signatures.
+//! Everything an [`IntBits`] can *do* lives on [`IntBits`], in `int_bits.rs`. What is left here is
+//! the part of the model with **no receiver**: [`eval`] and [`residue`], whose subject is the
+//! _operation_ rather than the left operand, plus the vocabulary they take and the width rule they
+//! enforce.
 //!
 //! # The Source of the Rules
 //!
@@ -79,7 +83,11 @@
 
 pub mod corners;
 pub mod corpus;
+pub mod int_bits;
 pub mod register;
+
+pub use int_bits::IntBits;
+use num_bigint::{BigInt, BigUint};
 
 // CONSTANTS
 // ================================================================================================
@@ -97,62 +105,147 @@ pub const MAX_SIGNED_BITS: usize = 64;
 // PAYLOAD TYPES
 // ================================================================================================
 
-/// A raw integer bit pattern, always masked to its operand's width.
+/// The two's-complement _reading_ of an [`IntBits`], as a mathematical integer.
 ///
-/// An alias rather than a spelled-out host type because the host type is an implementation detail:
-/// `u128` covers every width Mavros supports today ([`MAX_BITS`]), and the day an integer type
-/// exceeds that, this becomes a bignum without a single consumer's signature changing.
-///
-/// The alias is deliberately confined to _signatures_. Expressions that genuinely depend on the
-/// host — `1u128 << k`, `checked_mul`, a `proptest` strategy over `u128` — stay spelled out, so
-/// that widening the alias produces compile errors at exactly the places that need real thought
-/// rather than silently appearing to be free.
-pub type Raw = u128;
-
-/// The two's-complement _reading_ of a [`Raw`], as a mathematical integer.
-///
-/// A distinct alias because it is a number rather than a pattern: it goes negative, and it needs a
-/// bit more room than the width it decodes so that [`signed_min`] is representable at that width.
-/// Signed operations are capped at [`MAX_SIGNED_BITS`], well inside `i128`, so this one has far
-/// more headroom than [`Raw`] does.
-pub type SignedValue = i128;
+/// Named rather than spelled `BigInt` at every site so that what backs a signed reading stays this
+/// crate's business. [`IntBits`] itself is the payload type and is named directly: it is Mavros's
+/// own, so there is nothing to hide behind an alias.
+pub type SignedValue = BigInt;
 
 // INTEGER OPERATIONS MODEL
 // ================================================================================================
 
-/// A sign-agnostic binary integer operation.
+/// One binary integer operation, with the signedness reading it uses.
 ///
-/// The sign is [`Sign`], carried separately, as not all operations have a signed reading.
+/// # Which Operations Come in Pairs
+///
+/// Every operation whose _answer or acceptance_ depends on its choice of signedness comes in a
+/// pair:
+///
+/// - `Div`, `Rem` and `Shr` compute **different values**.
+/// - `Add`, `Sub` and `Mul` compute the same bits whenever they succeed, and differ in **when they
+///   fail**.
+/// - `And`, `Or` and `Xor` have no reading at all, and neither does `Shl`: it wraps under both
+///   readings and its amount is read as an unsigned magnitude either way.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum IntOp {
-    Add,
-    Sub,
-    Mul,
-    Div,
-    Rem,
+    UAdd,
+    SAdd,
+    USub,
+    SSub,
+    UMul,
+    SMul,
+    UDiv,
+    SDiv,
+    URem,
+    SRem,
     And,
     Or,
     Xor,
     Shl,
-    Shr,
+    UShr,
+    SShr,
 }
 
 impl IntOp {
     /// Every operation, for exhaustive sweeps.
-    pub const ALL: [IntOp; 10] = [
-        IntOp::Add,
-        IntOp::Sub,
-        IntOp::Mul,
-        IntOp::Div,
-        IntOp::Rem,
+    ///
+    /// Ordered unsigned-then-signed within each group, and the groups in the order the generated
+    /// corpus renders them, so that grouping by [`IntOp::name`] reproduces the file and cell order
+    /// the checked-in `noir_tests/int_semantics_*` directories were blessed at.
+    pub const ALL: [IntOp; 16] = [
+        IntOp::UAdd,
+        IntOp::SAdd,
+        IntOp::USub,
+        IntOp::SSub,
+        IntOp::UMul,
+        IntOp::SMul,
+        IntOp::UDiv,
+        IntOp::SDiv,
+        IntOp::URem,
+        IntOp::SRem,
         IntOp::And,
         IntOp::Or,
         IntOp::Xor,
         IntOp::Shl,
-        IntOp::Shr,
+        IntOp::UShr,
+        IntOp::SShr,
     ];
 
-    /// Whether the signed and unsigned readings of this operation can give different answers.
+    /// The reading this operation names, or [`None`] where it names none.
+    ///
+    /// `None` is not "unsigned": it is the statement that this operation gives one answer whatever
+    /// the operands were meant as. Only the width checks distinguish the two as a signed cap has
+    /// nothing to say about an operation with no signed form.
+    #[must_use]
+    pub const fn sign(self) -> Option<Sign> {
+        match self {
+            IntOp::SAdd | IntOp::SSub | IntOp::SMul | IntOp::SDiv | IntOp::SRem | IntOp::SShr => {
+                Some(Sign::Signed)
+            }
+            IntOp::UAdd | IntOp::USub | IntOp::UMul | IntOp::UDiv | IntOp::URem | IntOp::UShr => {
+                Some(Sign::Unsigned)
+            }
+            IntOp::And | IntOp::Or | IntOp::Xor | IntOp::Shl => None,
+        }
+    }
+
+    /// Whether this operation reads its operands as two's complement.
+    ///
+    /// The reading-free operations answer `false`, which describes what they do to the raw pattern.
+    /// A caller that needs to tell "unsigned" from "the question does not arise" wants
+    /// [`IntOp::sign`].
+    #[must_use]
+    pub const fn is_signed(self) -> bool {
+        matches!(self.sign(), Some(Sign::Signed))
+    }
+
+    /// The name this operation's group carries in the generated corpus and in a diagnostic.
+    ///
+    /// Sign-erased, because a Noir program has one `+` and the type of its operands is what picks
+    /// the reading. It is also how [`corpus`] groups the split variants back into one test file per
+    /// operator.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            IntOp::UAdd | IntOp::SAdd => "add",
+            IntOp::USub | IntOp::SSub => "sub",
+            IntOp::UMul | IntOp::SMul => "mul",
+            IntOp::UDiv | IntOp::SDiv => "div",
+            IntOp::URem | IntOp::SRem => "rem",
+            IntOp::And => "and",
+            IntOp::Or => "or",
+            IntOp::Xor => "xor",
+            IntOp::Shl => "shl",
+            IntOp::UShr | IntOp::SShr => "shr",
+        }
+    }
+
+    /// The Noir operator this lowers from.
+    #[must_use]
+    pub const fn symbol(self) -> &'static str {
+        match self {
+            IntOp::UAdd | IntOp::SAdd => "+",
+            IntOp::USub | IntOp::SSub => "-",
+            IntOp::UMul | IntOp::SMul => "*",
+            IntOp::UDiv | IntOp::SDiv => "/",
+            IntOp::URem | IntOp::SRem => "%",
+            IntOp::And => "&",
+            IntOp::Or => "|",
+            IntOp::Xor => "^",
+            IntOp::Shl => "<<",
+            IntOp::UShr | IntOp::SShr => ">>",
+        }
+    }
+
+    /// Whether the two readings of this operation take **different routes through the lowering**.
+    ///
+    /// Not "give different answers", which would be wrong about `Shl`: a left shift wraps
+    /// identically under both readings, and what its signed form additionally owns is a rejecting
+    /// constraint on a negative _amount_. The corpus generator
+    /// reads this to decide how many operand pairs a cell is worth, so the set it picks out is
+    /// load-bearing on the blessed test files — it is exactly the operations with a signed form
+    /// plus `Shl`, or equivalently everything but the three bitwise ones.
     #[must_use]
     pub const fn reading_matters(self) -> bool {
         !matches!(self, IntOp::And | IntOp::Or | IntOp::Xor)
@@ -160,12 +253,43 @@ impl IntOp {
 
     /// Whether this operation reads its right operand at a width of its **own**.
     ///
-    /// True for the two shifts, whose amount carries its own type, and false for everything else,
+    /// True for the shifts, whose amount carries its own type, and false for everything else,
     /// where the two operands are one width and a caller offering two widths is offering a
     /// contradiction. The width checks every entry point performs are what act on the answer.
     #[must_use]
-    pub const fn has_own_amount_width(self) -> bool {
-        matches!(self, IntOp::Shl | IntOp::Shr)
+    pub const fn is_shift(self) -> bool {
+        matches!(self, IntOp::Shl | IntOp::UShr | IntOp::SShr)
+    }
+}
+
+/// A comparison, with the reading it names.
+///
+/// The same shape as HLSSA's `CmpKind` and LLSSA's `IntCmpOp`, which is the point: equality needs
+/// no reading — two patterns of one width are equal under either — so only the ordering comes in
+/// a pair.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum CmpOp {
+    /// Pattern equality.
+    Eq,
+
+    /// Less-than as unsigned magnitudes.
+    ULt,
+
+    /// Less-than as two's complement.
+    SLt,
+}
+
+impl CmpOp {
+    pub const ALL: [CmpOp; 3] = [CmpOp::Eq, CmpOp::ULt, CmpOp::SLt];
+
+    /// The reading this comparison names, or [`None`] for [`CmpOp::Eq`].
+    #[must_use]
+    pub const fn sign(self) -> Option<Sign> {
+        match self {
+            CmpOp::Eq => None,
+            CmpOp::ULt => Some(Sign::Unsigned),
+            CmpOp::SLt => Some(Sign::Signed),
+        }
     }
 }
 
@@ -218,10 +342,12 @@ pub enum Reject {
 // ================================================================================================
 
 /// What an evaluation does.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+///
+/// No [`Copy`], because a [`IntBits`] is a heap-backed pattern rather than a host word.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Outcome {
     /// Noir computes this raw pattern, masked to the operand width.
-    Value(Raw),
+    Value(IntBits),
 
     /// Noir rejects the program at runtime.
     Rejected(Reject),
@@ -230,7 +356,7 @@ pub enum Outcome {
 impl Outcome {
     /// The value, if this evaluation is accepted.
     #[must_use]
-    pub const fn value(self) -> Option<Raw> {
+    pub fn value(self) -> Option<IntBits> {
         match self {
             Outcome::Value(v) => Some(v),
             Outcome::Rejected(_) => None,
@@ -238,99 +364,45 @@ impl Outcome {
     }
 
     #[must_use]
-    pub const fn is_rejected(self) -> bool {
+    pub const fn is_rejected(&self) -> bool {
         matches!(self, Outcome::Rejected(_))
     }
 }
 
-// BIT-PATTERN HELPERS
+// HOST-WORD HELPER
 // ================================================================================================
 
-/// All-ones mask for the low `bits` bits, total at the edges.
+/// All-ones for the low `bits` bits, as a **host word**, total at the edges.
+///
+/// The one free function here that is not part of the model, and a host word rather than a method
+/// on [`IntBits`] because it takes no operand and answers no value: there is no integer for it to
+/// be an operation _on_. Its callers are the
+/// ones genuinely working in `u64`s and `u128`s — the limb recombination in [`IntBits`], and the
+/// compiler's remaining host-word arithmetic — so it stops being expressible the moment a width
+/// outruns the host, which is the intended failure. The pattern of the same shape is
+/// [`IntBits::all_ones`].
+///
+/// The saturation bound is the **host's** width and deliberately not [`MAX_BITS`], even though the
+/// two are the same number today. The claim being made is that a `u128` cannot hold more than 128
+/// bits, which is a fact about the host; writing it as the model's cap would leave `mask` correct
+/// only for as long as that cap stays at 128, and the arm below is `1u128 << bits` — a debug panic
+/// and, worse, a release build that masks the shift amount and answers a plausible wrong number.
 #[must_use]
-pub fn mask(bits: usize) -> Raw {
+pub fn mask(bits: usize) -> u128 {
     if bits == 0 {
         0
-    } else if bits >= MAX_BITS {
+    } else if bits >= u128::BITS as usize {
         u128::MAX
     } else {
         (1u128 << bits) - 1
     }
 }
 
-/// Read a `bits`-wide raw pattern as two's complement.
-///
-/// Bits above `bits` are discarded first, so this is correct on a cell that some earlier step left
-/// dirty above its declared width.
-#[must_use]
-pub fn decode_signed(bits: usize, raw: Raw) -> SignedValue {
-    debug_assert!((1..=MAX_SIGNED_BITS).contains(&bits));
-    let raw = raw & mask(bits);
-    if (raw >> (bits - 1)) & 1 == 1 {
-        (raw as i128) - (1i128 << bits)
-    } else {
-        raw as i128
-    }
-}
-
-/// Encode a signed value as a `bits`-wide raw pattern.
-#[must_use]
-pub fn encode_signed(bits: usize, v: SignedValue) -> Raw {
-    (v as u128) & mask(bits)
-}
-
-/// Whether `v` is representable in `bits`-bit two's complement.
-#[must_use]
-pub fn fits_signed(bits: usize, v: SignedValue) -> bool {
-    debug_assert!((1..=MAX_SIGNED_BITS).contains(&bits));
-    v >= -(1i128 << (bits - 1)) && v < (1i128 << (bits - 1))
-}
-
-/// The largest value a `bits`-wide signed pattern represents.
-#[must_use]
-pub fn signed_max(bits: usize) -> SignedValue {
-    (1i128 << (bits - 1)) - 1
-}
-
-/// The smallest value a `bits`-wide signed pattern represents.
-#[must_use]
-pub fn signed_min(bits: usize) -> SignedValue {
-    -(1i128 << (bits - 1))
-}
-
-/// Widen a `from`-bit two's-complement pattern to `to` bits, replicating the sign bit.
-///
-/// Operates on the pattern. Narrowing is not sign extension and is rejected rather than silently
-/// truncating.
-#[must_use]
-pub fn sign_extend(v: Raw, from: usize, to: usize) -> Raw {
-    debug_assert!(from > 0 && to >= from, "cannot sign-extend {from} to {to}");
-    let v = v & mask(from);
-    if (v >> (from - 1)) & 1 == 1 {
-        v | (mask(to) ^ mask(from))
-    } else {
-        v
-    }
-}
-
-/// The amount a `bits`-wide shift actually applies to a pattern the guard IR failed to reject.
-///
-/// `amount & (bits - 1)`. Note it is a **mask, not a modulo**, which is fine and deliberate as the
-/// result is a submask of `bits - 1` and so always below `bits`, which is all a backstop needs to
-/// guarantee.
-#[must_use]
-pub fn masked_shift_amount(amount: Raw, bits: usize) -> u32 {
-    (amount & (bits as u128).saturating_sub(1)) as u32
-}
-
 // THE MODEL
 // ================================================================================================
 
-/// Check the width arguments every entry point shares.
-///
-/// `op` is [`None`] for the entry points that have no [`IntOp`] at all, which is [`cmp`]; those
-/// read both operands at one width by construction and pass `bits` twice.
-fn check_widths(op: Option<IntOp>, sign: Sign, bits: usize, rhs_bits: usize) {
+/// Check the widths the operands arrived carrying.
+pub(crate) fn check_widths(signed: bool, is_shift: bool, bits: usize, rhs_bits: usize) {
     assert!(
         (1..=MAX_BITS).contains(&bits),
         "operand width {bits} is outside 1..={MAX_BITS}"
@@ -340,110 +412,119 @@ fn check_widths(op: Option<IntOp>, sign: Sign, bits: usize, rhs_bits: usize) {
         "right-operand width {rhs_bits} is outside 1..={MAX_BITS}"
     );
     assert!(
-        !sign.is_signed() || bits <= MAX_SIGNED_BITS,
+        !signed || bits <= MAX_SIGNED_BITS,
         "signed operation on a {bits}-bit value exceeds {MAX_SIGNED_BITS}"
     );
     assert!(
-        rhs_bits == bits || op.is_some_and(IntOp::has_own_amount_width),
-        "{op:?} was given operand widths {bits} and {rhs_bits}; only a shift reads its right operand at a width of its own"
+        rhs_bits == bits || is_shift,
+        "operand widths {bits} and {rhs_bits}; only a shift reads its right operand at a width of its own"
     );
 }
 
 /// Noir's specification for one integer operation.
 ///
-/// `lhs` and `rhs` are raw patterns and anything above their declared width is discarded, so a
-/// caller need not pre-mask. `rhs_bits` is separate from `bits` because a shift amount legitimately
-/// has its own width.
-///
 /// # Panics
 ///
-/// If the widths are outside `1..=128`, or a signed op is requested above [`MAX_SIGNED_BITS`].
-/// Those are compiler bugs rather than program errors, so they are not [`Reject`] variants.
+/// If either width is outside `1..=128`, if a signed operation is asked of a pattern above
+/// [`MAX_SIGNED_BITS`], or if a non-shift is given two operands of different widths. Those are
+/// compiler bugs rather than program errors, so they are not [`Reject`] variants.
 #[must_use]
-pub fn eval(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs_bits: usize, rhs: Raw) -> Outcome {
-    check_widths(Some(op), sign, bits, rhs_bits);
-    let lhs = lhs & mask(bits);
-    let rhs = rhs & mask(rhs_bits);
+pub fn eval(op: IntOp, lhs: &IntBits, rhs: &IntBits) -> Outcome {
+    let bits = lhs.bits();
+    check_widths(op.is_signed(), op.is_shift(), bits, rhs.bits());
 
-    // Bitwise operations have no reading and cannot fail, so they short-circuit both arms below.
     match op {
-        IntOp::And => return Outcome::Value(lhs & rhs),
-        IntOp::Or => return Outcome::Value(lhs | rhs),
-        IntOp::Xor => return Outcome::Value(lhs ^ rhs),
-        _ => {}
-    }
+        // Bitwise operations have no reading and cannot fail, so they answer here. They are also
+        // the only arms that stay on the pattern throughout: everything past this point needs a
+        // number, and a number is what a pattern is not.
+        IntOp::And => Outcome::Value(lhs.and(rhs)),
+        IntOp::Or => Outcome::Value(lhs.or(rhs)),
+        IntOp::Xor => Outcome::Value(lhs.xor(rhs)),
 
-    if matches!(op, IntOp::Shl | IntOp::Shr) {
-        return eval_shift(op, sign, bits, lhs, rhs);
-    }
+        IntOp::Shl | IntOp::UShr | IntOp::SShr => eval_shift(op, lhs, rhs),
 
-    if sign.is_signed() {
-        eval_signed_arith(op, bits, decode_signed(bits, lhs), decode_signed(bits, rhs))
-    } else {
-        eval_unsigned_arith(op, bits, lhs, rhs)
+        IntOp::SAdd | IntOp::SSub | IntOp::SMul | IntOp::SDiv | IntOp::SRem => {
+            eval_signed_arith(op, bits, &lhs.to_signed(), &rhs.to_signed())
+        }
+        IntOp::UAdd | IntOp::USub | IntOp::UMul | IntOp::UDiv | IntOp::URem => {
+            eval_unsigned_arith(op, lhs, rhs)
+        }
     }
 }
 
-fn eval_unsigned_arith(op: IntOp, bits: usize, lhs: Raw, rhs: Raw) -> Outcome {
-    let checked = match op {
-        IntOp::Add => lhs.checked_add(rhs),
-        IntOp::Sub => lhs.checked_sub(rhs),
-        IntOp::Mul => lhs.checked_mul(rhs),
-        IntOp::Div | IntOp::Rem => {
-            if rhs == 0 {
+fn eval_unsigned_arith(op: IntOp, lhs: &IntBits, rhs: &IntBits) -> Outcome {
+    // Both operands are one width here — a shift never reaches this function — so either says what
+    // the result is held to. The signed arm below still takes it as a parameter, because by then
+    // the operands are `SignedValue`s and a mathematical integer has no width to read.
+    let bits = lhs.bits();
+    let (lhs, rhs) = (BigUint::from(lhs), BigUint::from(rhs));
+
+    let result = match op {
+        IntOp::UAdd => lhs + rhs,
+        // A `BigUint` has no negatives to fall into, so underflow is a test rather than a failed
+        // subtraction. It is the same rejection either way: a difference below zero does not fit.
+        IntOp::USub => {
+            if lhs < rhs {
+                return Outcome::Rejected(Reject::Overflow);
+            }
+            lhs - rhs
+        }
+        IntOp::UMul => lhs * rhs,
+        IntOp::UDiv | IntOp::URem => {
+            if rhs == BigUint::ZERO {
                 return Outcome::Rejected(Reject::DivByZero);
             }
             // A quotient or remainder of two in-range values is always in range, so neither of
             // these can fail the width check below.
-            Some(if op == IntOp::Div {
+            if op == IntOp::UDiv {
                 lhs / rhs
             } else {
                 lhs % rhs
-            })
+            }
         }
-        IntOp::And | IntOp::Or | IntOp::Xor | IntOp::Shl | IntOp::Shr => {
-            unreachable!("handled before this function")
-        }
+        _ => unreachable!("{op:?} does not reach the unsigned arithmetic arm"),
     };
 
-    // `checked_*` catches only a 128-bit overflow; the operand width is usually much narrower, so
-    // the width test is what actually rejects. Underflow arrives here as `checked_sub` failing.
-    match checked {
-        Some(v) if v <= mask(bits) => Outcome::Value(v),
-        _ => Outcome::Rejected(Reject::Overflow),
+    // The width test, stated as the number of significant bits rather than against a mask, so that
+    // it says what it means at a width no host word could hold.
+    if result.bits() <= bits as u64 {
+        Outcome::Value(IntBits::from_biguint(bits, &result))
+    } else {
+        Outcome::Rejected(Reject::Overflow)
     }
 }
 
-fn eval_signed_arith(op: IntOp, bits: usize, lhs: SignedValue, rhs: SignedValue) -> Outcome {
-    let checked = match op {
-        IntOp::Add => lhs.checked_add(rhs),
-        IntOp::Sub => lhs.checked_sub(rhs),
-        IntOp::Mul => lhs.checked_mul(rhs),
-        IntOp::Div | IntOp::Rem => {
-            if rhs == 0 {
+fn eval_signed_arith(op: IntOp, bits: usize, lhs: &SignedValue, rhs: &SignedValue) -> Outcome {
+    // No `checked_*` layer on either arm: these are mathematical integers, so there is no host
+    // range to fall out of, and the width test below is the only test there is.
+    let result = match op {
+        IntOp::SAdd => lhs + rhs,
+        IntOp::SSub => lhs - rhs,
+        IntOp::SMul => lhs * rhs,
+        IntOp::SDiv | IntOp::SRem => {
+            if *rhs == SignedValue::from(0u8) {
                 return Outcome::Rejected(Reject::DivByZero);
             }
-            if lhs == signed_min(bits) && rhs == -1 {
+            if *lhs == IntBits::signed_min(bits) && *rhs == SignedValue::from(-1i8) {
                 return Outcome::Rejected(Reject::DivOverflow);
             }
 
-            // Rust's `/` and `%` are Noir's: truncation toward zero, remainder signed like the
-            // dividend. `expand_signed_math` builds the same thing out of a magnitude division
-            // plus a sign fix-up.
-            Some(if op == IntOp::Div {
+            // `BigInt`'s `/` and `%` are Rust's, which are Noir's: truncation toward zero,
+            // remainder signed like the dividend. `expand_signed_math` builds the same thing out
+            // of a magnitude division plus a sign fix-up.
+            if op == IntOp::SDiv {
                 lhs / rhs
             } else {
                 lhs % rhs
-            })
+            }
         }
-        IntOp::And | IntOp::Or | IntOp::Xor | IntOp::Shl | IntOp::Shr => {
-            unreachable!("handled before this function")
-        }
+        _ => unreachable!("{op:?} does not reach the signed arithmetic arm"),
     };
 
-    match checked {
-        Some(v) if fits_signed(bits, v) => Outcome::Value(encode_signed(bits, v)),
-        _ => Outcome::Rejected(Reject::Overflow),
+    if IntBits::fits_signed(bits, &result) {
+        Outcome::Value(IntBits::from_signed(bits, &result))
+    } else {
+        Outcome::Rejected(Reject::Overflow)
     }
 }
 
@@ -453,23 +534,26 @@ fn eval_signed_arith(op: IntOp, bits: usize, lhs: SignedValue, rhs: SignedValue)
 /// hold any pattern its width allows. Laxer about the result: a `<<` that pushes bits off the top
 /// **wraps** and is not an error at all. `remove_bit_shifts` lowers it as a multiply in the field
 /// followed by a truncation, so the discarded bits are discarded by construction.
-fn eval_shift(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs: Raw) -> Outcome {
+fn eval_shift(op: IntOp, lhs: &IntBits, rhs: &IntBits) -> Outcome {
+    let bits = lhs.bits();
+
     // The amount is read as an unsigned magnitude whatever the operation's sign.
-    if rhs >= bits as u128 {
+    let magnitude = BigUint::from(rhs);
+    if magnitude >= BigUint::from(bits) {
         return Outcome::Rejected(Reject::ShiftAmount);
     }
-    let amount = rhs as u32;
+    let amount = usize::try_from(&magnitude).expect("an amount below the width fits a usize");
 
-    let value = match (op, sign) {
-        // One map on the bit pattern whatever the reading, then truncate. The result can change
-        // sign (`64i8 << 1` is `-128`), which is why this stays on the raw pattern rather than
-        // asking whether the mathematical product fits.
-        (IntOp::Shl, _) => lhs.wrapping_shl(amount) & mask(bits),
-        (IntOp::Shr, Sign::Unsigned) => lhs >> amount,
+    let value = match op {
+        // One map on the bit pattern whatever the reading, which is why `Shl` is a single variant.
+        // The result can change sign (`64i8 << 1` is `-128`), so this stays on the raw pattern
+        // rather than asking whether the mathematical product fits.
+        IntOp::Shl => lhs.shifted_left(amount),
+        IntOp::UShr => lhs.shifted_right(amount),
         // Sign-filling, so it saturates at `-1` rather than reaching zero. The magnitude only
         // shrinks, so it can never leave the width.
-        (IntOp::Shr, Sign::Signed) => encode_signed(bits, decode_signed(bits, lhs) >> amount),
-        _ => unreachable!("only shifts reach this function"),
+        IntOp::SShr => IntBits::from_signed(bits, &(lhs.to_signed() >> amount)),
+        _ => unreachable!("{op:?} is not a shift"),
     };
     Outcome::Value(value)
 }
@@ -489,193 +573,49 @@ fn eval_shift(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs: Raw) -> Outcome
 ///
 /// As [`eval`] does, on invalid widths.
 #[must_use]
-pub fn residue(
-    op: IntOp,
-    sign: Sign,
-    bits: usize,
-    lhs: Raw,
-    rhs_bits: usize,
-    rhs: Raw,
-) -> Option<Raw> {
-    check_widths(Some(op), sign, bits, rhs_bits);
+pub fn residue(op: IntOp, lhs: &IntBits, rhs: &IntBits) -> Option<IntBits> {
+    let bits = lhs.bits();
 
-    match eval(op, sign, bits, lhs, rhs_bits, rhs) {
+    match eval(op, lhs, rhs) {
         Outcome::Value(v) => Some(v),
         Outcome::Rejected(Reject::Overflow) => {
-            let lhs = lhs & mask(bits);
-            let rhs = rhs & mask(rhs_bits);
-            Some(
-                match op {
-                    IntOp::Add => lhs.wrapping_add(rhs),
-                    IntOp::Sub => lhs.wrapping_sub(rhs),
-                    IntOp::Mul => lhs.wrapping_mul(rhs),
-                    _ => unreachable!("only add/sub/mul overflow"),
-                } & mask(bits),
-            )
+            // One formula for both readings. Wrapping _is_ arithmetic modulo `2^bits`, and which
+            // reading the operands were meant as does not change the bits of a sum, difference or
+            // product — so the exact result
+            // taken through `IntBits::from_signed`, which reduces modulo the width, is the answer
+            // for signed and unsigned alike.
+            let lhs = SignedValue::from(BigUint::from(lhs));
+            let rhs = SignedValue::from(BigUint::from(rhs));
+            let exact = match op {
+                IntOp::UAdd | IntOp::SAdd => lhs + rhs,
+                IntOp::USub | IntOp::SSub => lhs - rhs,
+                IntOp::UMul | IntOp::SMul => lhs * rhs,
+                _ => unreachable!("{op:?} cannot overflow"),
+            };
+            Some(IntBits::from_signed(bits, &exact))
         }
         Outcome::Rejected(Reject::ShiftAmount) => {
-            // Re-entering `eval` keeps one definition of what a shift computes. The masked amount
-            // is a submask of the original, so it still fits `rhs_bits` and the re-entry cannot
-            // mask it a second time into something else, and it is below `bits`, so the re-entry
-            // cannot reject again and the `value()` is always `Some`.
-            let amount = masked_shift_amount(rhs & mask(rhs_bits), bits) as u128;
-            eval(op, sign, bits, lhs, rhs_bits, amount).value()
+            // Re-entering `eval` keeps one definition of what a shift computes. The reduced amount
+            // is below `bits`, so the re-entry cannot reject again; it is carried at the amount's
+            // own width, which is where it fits by construction — the reduction is modulo `bits`,
+            // and the original amount was already representable at that width.
+            //
+            // The `expect` is what states that. A bare `value()` would turn a broken re-entry into
+            // a `None`, which this function documents as meaning something quite different: that
+            // the backends have no agreed answer. Widening that set silently is the failure to
+            // avoid, so the invariant is asserted rather than propagated.
+            let amount = IntBits::from_u128(rhs.bits(), u128::from(rhs.reduced_shift_amount(bits)));
+            Some(
+                eval(op, lhs, &amount)
+                    .value()
+                    .expect("a shift by an amount reduced below the width cannot reject"),
+            )
         }
 
         // LLVM calls both undefined; the VM answers zero and wraps respectively. No agreed answer,
         // so none is specified.
         Outcome::Rejected(Reject::DivByZero | Reject::DivOverflow) => None,
     }
-}
-
-// COMPARISON AND BIT-LEVEL OPERATIONS
-// ================================================================================================
-
-/// A comparison, sign-agnostic.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum CmpOp {
-    /// Pattern equality
-    Eq,
-
-    /// Less-than, read as the [`Sign`] says.
-    Lt,
-}
-
-/// Compare two `bits`-wide patterns.
-///
-/// # Panics
-///
-/// As [`eval`] does, on invalid widths.
-#[must_use]
-pub fn cmp(op: CmpOp, sign: Sign, bits: usize, lhs: Raw, rhs: Raw) -> bool {
-    check_widths(None, sign, bits, bits);
-    let (lhs, rhs) = (lhs & mask(bits), rhs & mask(bits));
-    match op {
-        CmpOp::Eq => lhs == rhs,
-        CmpOp::Lt if sign.is_signed() => decode_signed(bits, lhs) < decode_signed(bits, rhs),
-        CmpOp::Lt => lhs < rhs,
-    }
-}
-
-/// Reinterpret a pattern at a new width: truncate when narrowing, zero-extend when widening.
-///
-/// A cast in HLSSA is a raw-bit conversion and nothing more. Widening a _signed_ value is
-/// [`sign_extend`], a separate operation, because the frontend emits a separate opcode for it.
-#[must_use]
-pub fn cast_int(v: Raw, to_bits: usize) -> Raw {
-    v & mask(to_bits)
-}
-
-/// Extract `width` bits starting at `offset`, right-aligned. HLSSA's `BitRange`.
-///
-/// The truncation primitive: `BitRange(v, 0, n)` is the low `n` bits, and a logical `>>` by a
-/// constant is `BitRange(v, k, bits - k)`.
-#[must_use]
-pub fn bit_range(v: Raw, offset: usize, width: usize) -> Raw {
-    if offset >= MAX_BITS {
-        return 0;
-    }
-    (v >> offset) & mask(width)
-}
-
-/// Bitwise complement, held to the operand width.
-#[must_use]
-pub fn not(v: Raw, bits: usize) -> Raw {
-    !v & mask(bits)
-}
-
-/// The width of one limb of a **canonical field representation**.
-///
-/// Not a property of any particular field: `ark_ff`'s `BigInt<const N: usize>` is `[u64; N]`, so
-/// the limb _count_ `N` varies from field to field while the limb _width_ does not. It is named
-/// here so that [`field_limbs_to_int`]'s callers state the contract rather than each rediscovering
-/// the 64.
-pub const FIELD_LIMB_BITS: usize = 64;
-
-/// Recombine little-endian limbs of `limb_bits` each into a `bits`-wide integer.
-///
-/// The limb width is a parameter because Mavros has two unrelated kinds of limb, and conflating
-/// them is exactly the sort of bug this crate exists to make impossible: a canonical field
-/// representation is always [`FIELD_LIMB_BITS`] wide, while the witness decompositions in
-/// `witness_bitwise` use a width that is _derived from the field size_. Both are little-endian limb
-/// vectors and neither knows the other's width.
-///
-/// Only [`field_limbs_to_int`] calls this today, and the second kind is not about to: those limbs
-/// are values in the emitted IR rather than numbers the host holds, so they are recombined by
-/// instructions and never reach a function like this one. The parameter is therefore here to stop
-/// [`FIELD_LIMB_BITS`] being baked into the recombination rule, not because a caller is coming —
-/// which is why the field-shaped entry point below is the one everything is expected to use.
-///
-/// Each limb is masked to `limb_bits` first, so a caller packing a narrow limb into a wider
-/// container need not clear the space above it.
-///
-/// # Panics
-///
-/// If `limb_bits` is zero, which describes no representation at all.
-#[must_use]
-pub fn limbs_to_int(limbs: &[u64], limb_bits: usize, bits: usize) -> Raw {
-    debug_assert!((1..=MAX_BITS).contains(&bits));
-    assert!(limb_bits > 0, "a limb must be at least one bit wide");
-
-    // Limbs from here up contribute only bits the final mask discards. The bound also keeps the
-    // shift below in range: the largest offset it permits is `((MAX_BITS - 1) / limb_bits) *
-    // limb_bits`, which is at most `MAX_BITS - 1`.
-    let usable = MAX_BITS.div_ceil(limb_bits);
-    let limb_mask = mask(limb_bits);
-
-    let low = limbs
-        .iter()
-        .take(usable)
-        .enumerate()
-        .fold(0, |acc, (i, &limb)| {
-            acc | ((Raw::from(limb) & limb_mask) << (i * limb_bits))
-        });
-
-    low & mask(bits)
-}
-
-/// Read a field element's canonical little-endian limbs as a `bits`-wide integer.
-///
-/// The `Field -> Int` cast, and [`limbs_to_int`] at [`FIELD_LIMB_BITS`]. It takes the low `bits`
-/// bits of the **canonical** representation, so a caller holding a Montgomery form must convert
-/// first.
-///
-/// The slice is unsized because the limb count is a property of the field. A slice shorter than
-/// `bits` implies is not an error either: it simply describes a smaller element.
-#[must_use]
-pub fn field_limbs_to_int(limbs: &[u64], bits: usize) -> Raw {
-    limbs_to_int(limbs, FIELD_LIMB_BITS, bits)
-}
-
-/// Whether a field element's canonical limbs are entirely inside a `bits`-wide integer.
-///
-/// The companion of [`field_limbs_to_int`], which **truncates**: this is how a caller asks whether
-/// the truncation would lose anything, so that it can refuse rather than answer a number the
-/// element is not.
-///
-/// It lives here rather than at the call site because the two have to agree about which bits the
-/// read covers, and a caller working that boundary out a second time is how they come apart. The
-/// obvious spelling, "every limb from `bits / FIELD_LIMB_BITS` up is zero", is the same test as
-/// this one only while `bits` is a whole number of limbs — which is true of the one width that
-/// asks today, and is not a property of the question.
-#[must_use]
-pub fn field_limbs_fit(limbs: &[u64], bits: usize) -> bool {
-    debug_assert!((1..=MAX_BITS).contains(&bits));
-
-    // Limbs below `whole` are covered outright. The one at `whole` is covered only up to `spare`
-    // bits, and where `spare` is zero that shift asks for the whole limb, which is the answer
-    // wanted: at a width that ends on a limb boundary the limb above it is entirely outside.
-    let whole = bits / FIELD_LIMB_BITS;
-    let spare = bits % FIELD_LIMB_BITS;
-
-    limbs
-        .iter()
-        .enumerate()
-        .all(|(i, &limb)| match i.cmp(&whole) {
-            std::cmp::Ordering::Less => true,
-            std::cmp::Ordering::Equal => limb >> spare == 0,
-            std::cmp::Ordering::Greater => limb == 0,
-        })
 }
 
 // TESTS

--- a/int-semantics/src/register.rs
+++ b/int-semantics/src/register.rs
@@ -77,7 +77,7 @@ pub const EVALUATORS: &[Evaluator] = &[
             },
             Conformance {
                 path: "compiler/src/compiler/codegen/hlssa_to_r1cs.rs",
-                test: "an_out_of_range_shift_amount_masks_to_the_width",
+                test: "an_out_of_range_shift_amount_reduces_to_the_width",
             },
         ],
     },
@@ -94,7 +94,7 @@ pub const EVALUATORS: &[Evaluator] = &[
             },
             Conformance {
                 path: "compiler/src/compiler/analysis/instrumenter.rs",
-                test: "an_out_of_range_shift_amount_masks_rather_than_saturating",
+                test: "an_out_of_range_shift_amount_reduces_rather_than_saturating",
             },
         ],
     },

--- a/int-semantics/src/tests.rs
+++ b/int-semantics/src/tests.rs
@@ -5,27 +5,89 @@
 //! 1. The **Pins** are hand-written cases taken straight from Noir's own tests and documentation.
 //!    These ensure that the model matches Noir's semantics, rather than simply being internally
 //!    consistent.
-//! 2. The **Exhaustive** tests check every operand pair at `bits ∈ {1, 4, 8}` in both readings for
-//!    all ten operations. Structural bugs (masking, sign decode, boundary-off-by-one) are generic
-//!    across widths, so an exhaustive sweep here will highlight them.
+//! 2. The **Exhaustive** tests check every operand pair at `bits ∈ {1, 4, 8}` for every operation
+//!    in `IntOp::ALL`. There is no second sweep over a reading, because an operation names its
+//!    own: `UAdd` and `SAdd` are two of the sixteen rather than one operation under two signs.
+//!    Structural bugs (masking, sign decode, boundary-off-by-one) are generic across widths, so an
+//!    exhaustive sweep here will highlight them.
 //! 3. The **Property** tests run over the rest of the domain to provide extra coverage where the
 //!    exhaustive tier cannot.
 
+use num_bigint::BigUint;
 use proptest::prelude::*;
 
 use crate::{
-    CmpOp, FIELD_LIMB_BITS, IntOp, MAX_BITS, MAX_SIGNED_BITS, Outcome, Raw, Reject, Sign,
-    bit_range, cast_int, cmp, corners, decode_signed, encode_signed, eval, field_limbs_fit,
-    field_limbs_to_int, fits_signed, limbs_to_int, mask, masked_shift_amount, not, residue,
-    sign_extend, signed_max, signed_min,
+    CmpOp, IntBits, IntOp, MAX_BITS, MAX_SIGNED_BITS, Outcome, Reject, SignedValue, corners, eval,
+    int_bits::FIELD_LIMB_BITS, mask, residue,
 };
 
 // PROPTEST UTILITIES
 // ================================================================================================
 
+/// A `bits`-wide pattern built from a host word.
+///
+/// The tests below are written as the numbers they mean, not as [`IntBits`]es: a pin that says
+/// `200 + 100` overflows at eight bits is about the arithmetic, and burying it under a
+/// construction at every operand would hide exactly the thing it pins. So the host façade is here,
+/// in the handful of functions below, and nowhere else.
+fn pat(bits: usize, value: u128) -> IntBits {
+    IntBits::from_u128(bits, value)
+}
+
+/// The host word a pattern denotes, the other half of [`pat`].
+fn host(value: &IntBits) -> u128 {
+    u128::try_from(value).expect("a pattern no wider than MAX_BITS fits a host word")
+}
+
 /// Shorthand for the common equal-width call.
-fn ev(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs: Raw) -> Outcome {
-    eval(op, sign, bits, lhs, bits, rhs)
+fn ev(op: IntOp, bits: usize, lhs: u128, rhs: u128) -> Outcome {
+    eval(op, &pat(bits, lhs), &pat(bits, rhs))
+}
+
+/// An accepted `bits`-wide answer, for comparing against [`ev`].
+fn val(bits: usize, value: u128) -> Outcome {
+    Outcome::Value(pat(bits, value))
+}
+
+/// [`ev`]'s accepted answer as a host word, or [`None`] where it rejected.
+fn ev_value(op: IntOp, bits: usize, lhs: u128, rhs: u128) -> Option<u128> {
+    ev(op, bits, lhs, rhs).value().map(|v| host(&v))
+}
+
+/// `residue` as a host word.
+fn res(op: IntOp, bits: usize, lhs: u128, rhs_bits: usize, rhs: u128) -> Option<u128> {
+    residue(op, &pat(bits, lhs), &pat(rhs_bits, rhs)).map(|v| host(&v))
+}
+
+/// A small reading written the way the test means it, since a [`SignedValue`] has no literal.
+fn sv(v: i64) -> SignedValue {
+    SignedValue::from(v)
+}
+
+/// The `bits`-wide pattern denoting the reading `v`, as a host word.
+fn enc(bits: usize, v: i64) -> u128 {
+    host(&IntBits::from_signed(bits, &sv(v)))
+}
+
+/// `reduced_shift_amount` on a host word, carried at the widest width the model admits — which is
+/// how an amount reaches it from an evaluator that has not narrowed it.
+fn reduced(amount: u128, bits: usize) -> u32 {
+    pat(MAX_BITS, amount).reduced_shift_amount(bits)
+}
+
+/// `IntBits::compare` on host words.
+fn compare(op: CmpOp, bits: usize, lhs: u128, rhs: u128) -> bool {
+    pat(bits, lhs).compare(op, &pat(bits, rhs))
+}
+
+/// `IntBits::from_packed_limbs` as a host word.
+fn limb_int(limbs: &[u64], limb_bits: usize, bits: usize) -> u128 {
+    host(&IntBits::from_packed_limbs(limbs, limb_bits, bits))
+}
+
+/// `IntBits::from_field_limbs` as a host word.
+fn field_int(limbs: &[u64], bits: usize) -> u128 {
+    host(&IntBits::from_field_limbs(limbs, bits))
 }
 
 // LAYER 1: PINS AGAINST NOIR
@@ -37,110 +99,80 @@ fn arithmetic_overflow_is_rejected_not_wrapped() {
     // bit_size`. This is the rule mavros currently breaks for unguarded pure operations: every
     // backend wraps to 44 and the program runs clean.
     assert_eq!(
-        ev(IntOp::Add, Sign::Unsigned, 8, 200, 100),
+        ev(IntOp::UAdd, 8, 200, 100),
         Outcome::Rejected(Reject::Overflow)
     );
     // ... and the residue records what those backends compute, so a conformance test can hold them
     // to it without pretending it is the right answer.
-    assert_eq!(
-        residue(IntOp::Add, Sign::Unsigned, 8, 200, 8, 100),
-        Some(44)
-    );
+    assert_eq!(res(IntOp::UAdd, 8, 200, 8, 100), Some(44));
 
     // Unsigned subtraction below zero is an overflow, not a wrap to a large number.
     assert_eq!(
-        ev(IntOp::Sub, Sign::Unsigned, 8, 1, 2),
+        ev(IntOp::USub, 8, 1, 2),
         Outcome::Rejected(Reject::Overflow)
     );
-    assert_eq!(residue(IntOp::Sub, Sign::Unsigned, 8, 1, 8, 2), Some(255));
+    assert_eq!(res(IntOp::USub, 8, 1, 8, 2), Some(255));
 
     assert_eq!(
-        ev(IntOp::Mul, Sign::Unsigned, 8, 16, 16),
+        ev(IntOp::UMul, 8, 16, 16),
         Outcome::Rejected(Reject::Overflow)
     );
 
     // Signed overflow is the same story at the signed boundary.
-    let max = encode_signed(8, signed_max(8));
+    let max = host(&IntBits::from_signed(8, &IntBits::signed_max(8)));
     assert_eq!(
-        ev(IntOp::Add, Sign::Signed, 8, max, 1),
+        ev(IntOp::SAdd, 8, max, 1),
         Outcome::Rejected(Reject::Overflow)
     );
     assert_eq!(
-        residue(IntOp::Add, Sign::Signed, 8, max, 8, 1),
-        Some(encode_signed(8, signed_min(8))),
+        res(IntOp::SAdd, 8, max, 8, 1),
+        Some(host(&IntBits::from_signed(8, &IntBits::signed_min(8)))),
         "127i8 + 1 wraps to -128 in every backend"
     );
 
     // In range, so accepted, and the two readings differ on the same patterns.
-    assert_eq!(
-        ev(IntOp::Add, Sign::Unsigned, 8, 200, 55),
-        Outcome::Value(255)
-    );
-    assert_eq!(
-        ev(IntOp::Add, Sign::Signed, 8, 200, 55),
-        Outcome::Value(255)
-    );
+    assert_eq!(ev(IntOp::UAdd, 8, 200, 55), val(8, 255));
+    assert_eq!(ev(IntOp::SAdd, 8, 200, 55), val(8, 255));
 }
 
 #[test]
 fn division_rejects_a_zero_divisor_and_the_signed_overflow() {
-    for sign in Sign::ALL {
-        for op in [IntOp::Div, IntOp::Rem] {
-            assert_eq!(ev(op, sign, 8, 7, 0), Outcome::Rejected(Reject::DivByZero));
-            assert_eq!(
-                residue(op, sign, 8, 7, 8, 0),
-                None,
-                "no agreed answer exists"
-            );
-        }
+    for op in [IntOp::UDiv, IntOp::SDiv, IntOp::URem, IntOp::SRem] {
+        assert_eq!(ev(op, 8, 7, 0), Outcome::Rejected(Reject::DivByZero));
+        assert_eq!(res(op, 8, 7, 8, 0), None, "no agreed answer exists");
     }
 
     // `INT_MIN / -1` has a quotient one past the top of the type. `expand_signed_math` emits an
     // explicit constrain for exactly this pair.
-    let min = encode_signed(8, signed_min(8));
-    let minus_one = encode_signed(8, -1);
+    let min = host(&IntBits::from_signed(8, &IntBits::signed_min(8)));
+    let minus_one = enc(8, -1);
     assert_eq!(
-        ev(IntOp::Div, Sign::Signed, 8, min, minus_one),
+        ev(IntOp::SDiv, 8, min, minus_one),
         Outcome::Rejected(Reject::DivOverflow)
     );
     // `INT_MIN % -1` would produce 0, which is representable -- but Noir defines the remainder in
     // terms of the same quotient, so it rejects that too.
     assert_eq!(
-        ev(IntOp::Rem, Sign::Signed, 8, min, minus_one),
+        ev(IntOp::SRem, 8, min, minus_one),
         Outcome::Rejected(Reject::DivOverflow)
     );
     // The unsigned reading of the same patterns is 128 / 255, which is perfectly fine.
-    assert_eq!(
-        ev(IntOp::Div, Sign::Unsigned, 8, min, minus_one),
-        Outcome::Value(0)
-    );
+    assert_eq!(ev(IntOp::UDiv, 8, min, minus_one), val(8, 0));
 }
 
 #[test]
 fn signed_division_truncates_toward_zero() {
     // `noir_tests/signed_divmod` pins this, and it is what separates `/` from an arithmetic `>>`:
     // `-7 / 2` is -3 while `-7 >> 1` is -4.
-    let neg7 = encode_signed(8, -7);
-    assert_eq!(
-        ev(IntOp::Div, Sign::Signed, 8, neg7, 2).value(),
-        Some(encode_signed(8, -3))
-    );
-    assert_eq!(
-        ev(IntOp::Rem, Sign::Signed, 8, neg7, 2).value(),
-        Some(encode_signed(8, -1))
-    );
-    assert_eq!(
-        ev(IntOp::Shr, Sign::Signed, 8, neg7, 1).value(),
-        Some(encode_signed(8, -4))
-    );
+    let neg7 = enc(8, -7);
+    assert_eq!(ev_value(IntOp::SDiv, 8, neg7, 2), Some(enc(8, -3)));
+    assert_eq!(ev_value(IntOp::SRem, 8, neg7, 2), Some(enc(8, -1)));
+    assert_eq!(ev_value(IntOp::SShr, 8, neg7, 1), Some(enc(8, -4)));
 
     // The remainder follows the dividend, not the divisor.
-    let neg2 = encode_signed(8, -2);
-    assert_eq!(
-        ev(IntOp::Div, Sign::Signed, 8, 7, neg2).value(),
-        Some(encode_signed(8, -3))
-    );
-    assert_eq!(ev(IntOp::Rem, Sign::Signed, 8, 7, neg2).value(), Some(1));
+    let neg2 = enc(8, -2);
+    assert_eq!(ev_value(IntOp::SDiv, 8, 7, neg2), Some(enc(8, -3)));
+    assert_eq!(ev_value(IntOp::SRem, 8, 7, neg2), Some(1));
 }
 
 #[test]
@@ -148,22 +180,19 @@ fn a_left_shift_wraps_and_only_the_amount_can_reject() {
     // `noir_tests/specialized_shl_wrap` exists to pin this: 200 << 1 is 400, which keeps only its
     // low eight bits, so the answer is 144 and *not* a rejection. Losing bits off the top is the
     // specified behaviour of `<<`, unlike `*`, where it is an error.
+    assert_eq!(ev(IntOp::Shl, 8, 200, 1), val(8, 144));
     assert_eq!(
-        ev(IntOp::Shl, Sign::Unsigned, 8, 200, 1),
-        Outcome::Value(144)
-    );
-    assert_eq!(
-        ev(IntOp::Mul, Sign::Unsigned, 8, 200, 2),
+        ev(IntOp::UMul, 8, 200, 2),
         Outcome::Rejected(Reject::Overflow)
     );
 
     // A signed `<<` wraps across the sign boundary: 64i8 << 1 is -128.
     assert_eq!(
-        ev(IntOp::Shl, Sign::Signed, 8, 64, 1).value(),
-        Some(encode_signed(8, signed_min(8)))
+        ev_value(IntOp::Shl, 8, 64, 1),
+        Some(host(&IntBits::from_signed(8, &IntBits::signed_min(8))))
     );
     // ... which is why the model shifts the raw pattern rather than asking whether `64 * 2` fits.
-    assert_eq!(ev(IntOp::Shl, Sign::Signed, 8, 1, 7).value(), Some(0x80));
+    assert_eq!(ev_value(IntOp::Shl, 8, 1, 7), Some(0x80));
 }
 
 #[test]
@@ -171,37 +200,26 @@ fn a_shift_amount_at_or_above_the_width_is_rejected() {
     // `remove_bit_shifts`' module doc: "In all cases, if the shift amount is equal to or exceeds
     // the operand's number of bits, the result will be a constrain failure". The boundary is the
     // whole content of the rule, so both sides of it are pinned.
-    for op in [IntOp::Shl, IntOp::Shr] {
-        for sign in Sign::ALL {
-            assert!(
-                ev(op, sign, 8, 1, 7).value().is_some(),
-                "7 is the largest legal amount"
-            );
-            assert_eq!(
-                ev(op, sign, 8, 1, 8),
-                Outcome::Rejected(Reject::ShiftAmount)
-            );
-            assert_eq!(
-                ev(op, sign, 8, 1, 100),
-                Outcome::Rejected(Reject::ShiftAmount)
-            );
-        }
+    for op in [IntOp::Shl, IntOp::UShr, IntOp::SShr] {
+        assert!(
+            ev_value(op, 8, 1, 7).is_some(),
+            "7 is the largest legal amount"
+        );
+        assert_eq!(ev(op, 8, 1, 8), Outcome::Rejected(Reject::ShiftAmount));
+        assert_eq!(ev(op, 8, 1, 100), Outcome::Rejected(Reject::ShiftAmount));
     }
 
     // Noir's own `shl_overflow_u64` / `shr_overflow_u64` are a u64 shifted by 100.
-    for op in [IntOp::Shl, IntOp::Shr] {
-        assert_eq!(
-            ev(op, Sign::Unsigned, 64, 1, 100),
-            Outcome::Rejected(Reject::ShiftAmount)
-        );
+    for op in [IntOp::Shl, IntOp::UShr] {
+        assert_eq!(ev(op, 64, 1, 100), Outcome::Rejected(Reject::ShiftAmount));
     }
 
     // A *negative* amount is the same rejection and not a separate rule:
     // `enforce_bitshift_rhs_lt_bit_size` casts the amount to unsigned first, so -1 reads as a huge
     // magnitude. `shl_signed_regression_9592` is this case.
-    let minus_one = encode_signed(32, -1);
+    let minus_one = enc(32, -1);
     assert_eq!(
-        ev(IntOp::Shl, Sign::Signed, 32, 1, minus_one),
+        ev(IntOp::Shl, 32, 1, minus_one),
         Outcome::Rejected(Reject::ShiftAmount)
     );
 }
@@ -209,40 +227,33 @@ fn a_shift_amount_at_or_above_the_width_is_rejected() {
 #[test]
 fn a_right_shift_fills_by_its_reading() {
     // Unsigned zero-fills, signed sign-fills and saturates at -1 rather than reaching zero.
-    assert_eq!(
-        ev(IntOp::Shr, Sign::Unsigned, 8, 0xF0, 2),
-        Outcome::Value(0x3C)
-    );
-    assert_eq!(
-        ev(IntOp::Shr, Sign::Signed, 8, 0xF0, 2),
-        Outcome::Value(0xFC)
-    );
-    assert_eq!(
-        ev(IntOp::Shr, Sign::Signed, 8, 0xF0, 7).value(),
-        Some(encode_signed(8, -1))
-    );
-    assert_eq!(ev(IntOp::Shr, Sign::Signed, 8, 0, 7), Outcome::Value(0));
+    assert_eq!(ev(IntOp::UShr, 8, 0xF0, 2), val(8, 0x3C));
+    assert_eq!(ev(IntOp::SShr, 8, 0xF0, 2), val(8, 0xFC));
+    assert_eq!(ev_value(IntOp::SShr, 8, 0xF0, 7), Some(enc(8, -1)));
+    assert_eq!(ev(IntOp::SShr, 8, 0, 7), val(8, 0));
 }
 
 #[test]
 fn bitwise_operations_have_no_reading_and_never_reject() {
-    for sign in Sign::ALL {
-        assert_eq!(ev(IntOp::And, sign, 8, 0xF0, 0x3C), Outcome::Value(0x30));
-        assert_eq!(ev(IntOp::Or, sign, 8, 0xF0, 0x3C), Outcome::Value(0xFC));
-        assert_eq!(ev(IntOp::Xor, sign, 8, 0xF0, 0x3C), Outcome::Value(0xCC));
+    // There is no sign to sweep: these three have no signed form to disagree with, which is this
+    // test's claim made structural rather than checked.
+    assert_eq!(ev(IntOp::And, 8, 0xF0, 0x3C), val(8, 0x30));
+    assert_eq!(ev(IntOp::Or, 8, 0xF0, 0x3C), val(8, 0xFC));
+    assert_eq!(ev(IntOp::Xor, 8, 0xF0, 0x3C), val(8, 0xCC));
+    for op in [IntOp::And, IntOp::Or, IntOp::Xor] {
+        assert_eq!(op.sign(), None, "{op:?} must name no reading");
     }
 }
 
 #[test]
 fn comparison_reads_the_patterns_as_the_operation_says() {
     // 0xFB is 251 unsigned and -5 signed, so the two readings order it against 2 differently.
-    assert!(cmp(CmpOp::Lt, Sign::Signed, 8, 0xFB, 2));
-    assert!(!cmp(CmpOp::Lt, Sign::Unsigned, 8, 0xFB, 2));
-    // Equality needs no reading at all.
-    for sign in Sign::ALL {
-        assert!(cmp(CmpOp::Eq, sign, 8, 0xFB, 0xFB));
-        assert!(!cmp(CmpOp::Eq, sign, 8, 0xFB, 2));
-    }
+    assert!(compare(CmpOp::SLt, 8, 0xFB, 2));
+    assert!(!compare(CmpOp::ULt, 8, 0xFB, 2));
+    // Equality needs no reading at all, which is why there is one `Eq` rather than a pair.
+    assert!(compare(CmpOp::Eq, 8, 0xFB, 0xFB));
+    assert!(!compare(CmpOp::Eq, 8, 0xFB, 2));
+    assert_eq!(CmpOp::Eq.sign(), None);
 }
 
 #[test]
@@ -250,54 +261,49 @@ fn the_field_cast_reads_both_low_limbs() {
     // The bug this exists to prevent: reading only `limbs[0]` answers a different number for every
     // `Field as u128` above 2^64, which is exactly the range `u128` was added for.
     let limbs = [7u64, 1u64, 0, 0];
-    assert_eq!(field_limbs_to_int(&limbs, 128), (1u128 << 64) | 7);
-    assert_eq!(
-        field_limbs_to_int(&limbs, 64),
-        7,
-        "narrowing still truncates"
-    );
-    assert_eq!(field_limbs_to_int(&limbs, 8), 7);
+    assert_eq!(field_int(&limbs, 128), (1u128 << 64) | 7);
+    assert_eq!(field_int(&limbs, 64), 7, "narrowing still truncates");
+    assert_eq!(field_int(&limbs, 8), 7);
 }
 
 #[test]
 fn the_field_cast_is_indifferent_to_the_limb_count() {
     // bn254 has four limbs and a smaller field has fewer, so the count is the field's business and
     // not this crate's. Every one of these describes the same element.
-    assert_eq!(field_limbs_to_int(&[7u64], 128), 7);
-    assert_eq!(field_limbs_to_int(&[7u64, 0, 0], 128), 7);
-    assert_eq!(field_limbs_to_int(&[7u64, 0, 0, 0, 0, 0], 128), 7);
+    assert_eq!(field_int(&[7u64], 128), 7);
+    assert_eq!(field_int(&[7u64, 0, 0], 128), 7);
+    assert_eq!(field_int(&[7u64, 0, 0, 0, 0, 0], 128), 7);
 
     // Limbs past the second hold only bits `mask` discards, so a longer slice cannot change the
     // answer -- the guard against a future width picking them up silently.
     assert_eq!(
-        field_limbs_to_int(&[7u64, 1, u64::MAX, u64::MAX], 128),
+        field_int(&[7u64, 1, u64::MAX, u64::MAX], 128),
         (1u128 << 64) | 7
     );
-    assert_eq!(
-        field_limbs_to_int(&[], 128),
-        0,
-        "no limbs is the zero element"
-    );
+    assert_eq!(field_int(&[], 128), 0, "no limbs is the zero element");
 }
 
 #[test]
 fn the_fit_test_covers_exactly_the_bits_the_read_keeps() {
-    // The companion of the truncating read above: whatever `field_limbs_fit` accepts,
-    // `field_limbs_to_int` must have lost nothing from.
-    assert!(field_limbs_fit(&[7u64, 1, 0, 0], 128));
-    assert!(!field_limbs_fit(&[7u64, 1, 1, 0], 128));
-    assert!(!field_limbs_fit(&[0u64, 0, 0, 1], 128));
-    assert!(field_limbs_fit(&[], 128), "no limbs is the zero element");
+    // The companion of the truncating read above: whatever `IntBits::field_limbs_fit` accepts,
+    // `IntBits::from_field_limbs` must have lost nothing from.
+    assert!(IntBits::field_limbs_fit(&[7u64, 1, 0, 0], 128));
+    assert!(!IntBits::field_limbs_fit(&[7u64, 1, 1, 0], 128));
+    assert!(!IntBits::field_limbs_fit(&[0u64, 0, 0, 1], 128));
+    assert!(
+        IntBits::field_limbs_fit(&[], 128),
+        "no limbs is the zero element"
+    );
 
     // A width that does not end on a limb boundary is the case the obvious spelling gets wrong:
     // `70 / 64` is `1`, so "every limb from index 1 up is zero" would reject an element whose
     // seventieth bit is the highest one set, which fits perfectly well.
-    assert!(field_limbs_fit(&[u64::MAX, 0b11_1111, 0, 0], 70));
-    assert!(!field_limbs_fit(&[u64::MAX, 0b111_1111, 0, 0], 70));
+    assert!(IntBits::field_limbs_fit(&[u64::MAX, 0b11_1111, 0, 0], 70));
+    assert!(!IntBits::field_limbs_fit(&[u64::MAX, 0b111_1111, 0, 0], 70));
 
     // And the boundary width itself, where the limb above must be empty outright.
-    assert!(field_limbs_fit(&[u64::MAX, 0, 0, 0], 64));
-    assert!(!field_limbs_fit(&[u64::MAX, 1, 0, 0], 64));
+    assert!(IntBits::field_limbs_fit(&[u64::MAX, 0, 0, 0], 64));
+    assert!(!IntBits::field_limbs_fit(&[u64::MAX, 1, 0, 0], 64));
 
     // The relation the two entry points hold, swept over the corners: accepting means the read is
     // lossless, which is the only reason a caller asks.
@@ -310,12 +316,12 @@ fn the_fit_test_covers_exactly_the_bits_the_read_keeps() {
             [0, 0, 1, 0],
             [7, 1, 0, 0],
         ] {
-            if !field_limbs_fit(&limbs, bits) {
+            if !IntBits::field_limbs_fit(&limbs, bits) {
                 continue;
             }
             assert_eq!(
-                field_limbs_to_int(&limbs, bits),
-                field_limbs_to_int(&limbs, MAX_BITS),
+                field_int(&limbs, bits),
+                field_int(&limbs, MAX_BITS),
                 "{limbs:?} was said to fit {bits} bits but reading it there lost something"
             );
         }
@@ -328,69 +334,384 @@ fn limb_width_is_a_parameter_not_an_assumption() {
     // exactly the general one pinned at that width.
     let canonical = [7u64, 1, 0, 0];
     assert_eq!(
-        limbs_to_int(&canonical, FIELD_LIMB_BITS, 128),
-        field_limbs_to_int(&canonical, 128)
+        limb_int(&canonical, FIELD_LIMB_BITS, 128),
+        field_int(&canonical, 128)
     );
 
     // The witness decompositions in `witness_bitwise` use a limb width derived from the field size,
     // so the same little-endian vector says something different at a different width.
-    assert_eq!(limbs_to_int(&[7u64, 1, 0, 0], 32, 128), (1u128 << 32) | 7);
-    assert_eq!(limbs_to_int(&[1u64, 0, 1], 1, 128), 0b101);
+    assert_eq!(limb_int(&[7u64, 1, 0, 0], 32, 128), (1u128 << 32) | 7);
+    assert_eq!(limb_int(&[1u64, 0, 1], 1, 128), 0b101);
 
     // A narrow limb packed into a wider container carries junk above its width, which is the
     // caller's normal state rather than an error.
-    assert_eq!(limbs_to_int(&[u64::MAX], 32, 128), u128::from(u32::MAX));
+    assert_eq!(limb_int(&[u64::MAX], 32, 128), u128::from(u32::MAX));
 
     // A limb at least as wide as the result needs no recombination at all.
-    assert_eq!(limbs_to_int(&[7u64], MAX_BITS, 128), 7);
+    assert_eq!(limb_int(&[7u64], MAX_BITS, 128), 7);
 }
 
 #[test]
 #[should_panic(expected = "a limb must be at least one bit wide")]
 fn a_zero_width_limb_describes_no_representation() {
-    let _ = limbs_to_int(&[7u64], 0, 128);
+    let _ = limb_int(&[7u64], 0, 128);
+}
+
+// SIGN EXTENSION
+// ================================================================================================
+//
+// These are the tests that sweep the width extended *from*, which is what distinguishes
+// `sign_extend` from a widening cast: an implementation filling from a fixed width passes every
+// other test in this file.
+
+/// `IntBits::sign_extend` on host words.
+fn sext(raw: u128, from: usize, to: usize) -> u128 {
+    host(&pat(from, raw).sign_extend(to))
+}
+
+#[test]
+fn sign_extend_agrees_with_decode_encode() {
+    // The authoritative definition of sign extension is "same integer, wider encoding".
+    // Check the bit-twiddling against it exhaustively for every 4-bit and 8-bit value.
+    for from in [4usize, 8] {
+        for raw in 0..(1u128 << from) {
+            for to in [from, from + 1, 16, 32, 64] {
+                assert_eq!(
+                    sext(raw, from, to),
+                    host(&IntBits::from_signed(to, &pat(from, raw).to_signed())),
+                    "sign_extend({raw} at {from} bits, {to})"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn sign_extend_is_identity_at_equal_width() {
+    for from in [1usize, 7, 8, 32] {
+        for raw in [0u128, 1, mask(from), mask(from) >> 1] {
+            assert_eq!(sext(raw, from, from), raw & mask(from));
+        }
+    }
+}
+
+#[test]
+fn sign_extend_masks_its_input() {
+    // Bits above `from` are not part of the value and must not survive into the result. The
+    // masking happens one step earlier: an eight-bit pattern cannot carry a ninth bit, so building
+    // one from a wider host word is where the discarding is done.
+    assert_eq!(sext(0xFF00 | 0x01, 8, 16), 0x0001);
+    assert_eq!(sext(0xFF00 | 0x80, 8, 16), 0xFF80);
+}
+
+#[test]
+fn sign_extend_handles_full_width() {
+    // The full width must not overflow anything the fill is built from.
+    assert_eq!(sext(1, 1, 128), u128::MAX);
+    assert_eq!(sext(0, 1, 128), 0);
+}
+
+// THE VOCABULARY
+// ================================================================================================
+//
+// The reading lives on the operation rather than beside it. What these check is the *shape* of the
+// vocabulary: that the operations which behave differently are two, and the ones that behave
+// identically are one.
+
+#[test]
+fn every_operation_that_reads_its_operands_comes_in_a_pair() {
+    // Stated as a partition rather than a list, so that adding a variant without a partner, or a
+    // partner without a difference, fails here rather than being noticed later.
+    let mut paired: Vec<&str> = Vec::new();
+    let mut single: Vec<&str> = Vec::new();
+    for op in IntOp::ALL {
+        let name = op.name();
+        if op.sign().is_some() {
+            if !paired.contains(&name) {
+                paired.push(name);
+            }
+        } else {
+            single.push(name);
+        }
+    }
+    assert_eq!(paired, ["add", "sub", "mul", "div", "rem", "shr"]);
+    assert_eq!(single, ["and", "or", "xor", "shl"]);
+
+    // Each paired name really is two operations, and each single name really is one.
+    for name in paired {
+        let members: Vec<IntOp> = IntOp::ALL
+            .into_iter()
+            .filter(|o| o.name() == name)
+            .collect();
+        assert_eq!(members.len(), 2, "{name} is not a pair");
+        assert_ne!(
+            members[0].sign(),
+            members[1].sign(),
+            "{name} reads one way twice"
+        );
+    }
+}
+
+#[test]
+fn the_operations_with_no_reading_are_the_ones_that_answer_the_same_either_way() {
+    // The claim behind `And`/`Or`/`Xor`/`Shl` having no signed form, checked rather than asserted
+    // in prose: for every corner pair, the answer read as *signed* is the one signed arithmetic
+    // would have produced, and the answer read as *unsigned* is the one unsigned arithmetic would
+    // have produced. Both are derived here through `SignedValue`/`BigUint` rather than through
+    // `IntBits`'s own limb code, so this compares two routes rather than restating one.
+    //
+    // A signed `<<` differs from an unsigned one only in a rejecting constraint on a negative
+    // *amount*, which is guard IR and not something `eval` computes.
+    for bits in [1usize, 8, 64] {
+        for &lhs in &corners::values(bits) {
+            for &rhs in &corners::values(bits) {
+                let (l, r) = (pat(bits, lhs), pat(bits, rhs));
+
+                // The bitwise three, each derived twice: once over `BigInt`, whose operators read
+                // a negative as two's complement extended indefinitely, and once over `BigUint`,
+                // which is the plain magnitude. One answer has to satisfy both, and that is what
+                // "the same either way" means.
+                let (ls, rs) = (l.to_signed(), r.to_signed());
+                let (lu, ru) = (BigUint::from(&l), BigUint::from(&r));
+                for (op, signed_want, unsigned_want) in [
+                    (IntOp::And, &ls & &rs, &lu & &ru),
+                    (IntOp::Or, &ls | &rs, &lu | &ru),
+                    (IntOp::Xor, &ls ^ &rs, &lu ^ &ru),
+                ] {
+                    let Outcome::Value(got) = ev(op, bits, lhs, rhs) else {
+                        panic!("{op:?} cannot reject");
+                    };
+                    assert_eq!(
+                        got.to_signed(),
+                        signed_want,
+                        "{op:?} at {bits} on {lhs:#x} {rhs:#x} read as signed"
+                    );
+                    assert_eq!(
+                        BigUint::from(&got),
+                        unsigned_want,
+                        "{op:?} at {bits} on {lhs:#x} {rhs:#x} read as unsigned"
+                    );
+                }
+
+                // `Shl` is the one that has to be argued. Under the unsigned reading it is
+                // `lhs * 2^amount` truncated to the width; under the signed reading it is
+                // `lhs_signed * 2^amount` encoded back into the width. Both are the same bits,
+                // which is why there is one variant and not two.
+                let shifted = ev(IntOp::Shl, bits, lhs, rhs);
+                if rhs < bits as u128 {
+                    let amount = rhs as usize;
+                    let unsigned = IntBits::from_biguint(bits, &(BigUint::from(&l) << amount));
+                    let signed = IntBits::from_signed(bits, &(l.to_signed() << amount));
+                    assert_eq!(unsigned, signed, "the two readings of `<<` are one map");
+                    assert_eq!(
+                        shifted,
+                        Outcome::Value(unsigned),
+                        "shl at {bits} on {lhs:#x} {rhs:#x}"
+                    );
+                } else {
+                    assert_eq!(shifted, Outcome::Rejected(Reject::ShiftAmount));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn the_shift_pair_is_the_one_that_differs() {
+    // `>>` is where the reading changes the answer, which is why it splits where `<<` does not.
+    assert_eq!(ev_value(IntOp::UShr, 8, 0xF0, 4), Some(0x0F));
+    assert_eq!(ev_value(IntOp::SShr, 8, 0xF0, 4), Some(0xFF));
+
+    // Stated as the exact rule rather than the one pair above, so that the split is pinned by
+    // where the two forms part company: a non-zero amount fills the vacated top bits, and the two
+    // fill it differently exactly when there is a sign bit set to fill it with.
+    for bits in [1usize, 8, 32, 64] {
+        for &lhs in &corners::values(bits) {
+            let negative = pat(bits, lhs).to_signed() < sv(0);
+            for amount in 0..bits as u128 {
+                let logical = ev_value(IntOp::UShr, bits, lhs, amount);
+                let arithmetic = ev_value(IntOp::SShr, bits, lhs, amount);
+                assert_eq!(
+                    logical != arithmetic,
+                    negative && amount != 0,
+                    "{lhs:#x} >> {amount} at {bits} bits: {logical:?} vs {arithmetic:?}"
+                );
+            }
+        }
+    }
+}
+
+// THE WIDTHS THE OPERANDS ARRIVE CARRYING
+// ================================================================================================
+//
+// `check_widths` had no coverage at all while the widths were parameters, because a caller that
+// spelled them wrong was writing a bug in its own call rather than building a value. They come off
+// the operands now, so what these pin is that the model still refuses a pair no operation admits
+// -- and, in the shift's case, still admits the one pair that is legitimately mixed.
+
+#[test]
+#[should_panic(expected = "only a shift reads its right operand at a width of its own")]
+fn a_non_shift_refuses_two_widths() {
+    let _ = eval(IntOp::UAdd, &pat(8, 1), &pat(16, 1));
+}
+
+#[test]
+fn a_shift_takes_its_amount_at_whatever_width_it_arrives() {
+    // Noir's elaborator unifies a shift's amount with its value, but the IR does not require it and
+    // two evaluators pass a narrower amount through at runtime -- see `corners::shift_width_pairs`.
+    assert_eq!(eval(IntOp::Shl, &pat(8, 1), &pat(32, 3)), val(8, 8));
+    assert_eq!(
+        eval(IntOp::Shl, &pat(8, 1), &pat(MAX_BITS, 8)),
+        Outcome::Rejected(Reject::ShiftAmount),
+        "the bound is the value's width, not the amount's"
+    );
+}
+
+#[test]
+#[should_panic(expected = "an integer pattern is at least one bit wide")]
+fn a_zero_width_operand_cannot_even_be_built() {
+    // `check_widths` states `1..=MAX_BITS`, but the lower half of that range is not its to
+    // enforce: a width of zero is refused a whole layer earlier, when the operand is constructed.
+    // The upper half is live, since `MAX_BITS` is the model's cap rather than the type's.
+    let _ = eval(IntOp::UAdd, &pat(0, 0), &pat(0, 0));
+}
+
+#[test]
+#[should_panic(expected = "operand width 200 is outside")]
+fn an_operand_wider_than_the_model_admits_is_refused() {
+    let _ = eval(IntOp::UAdd, &pat(200, 1), &pat(200, 1));
+}
+
+#[test]
+#[should_panic(expected = "signed operation on a 128-bit value")]
+fn a_signed_reading_stops_where_the_lowerings_do() {
+    let _ = eval(IntOp::SAdd, &pat(128, 1), &pat(128, 1));
+}
+
+#[test]
+#[should_panic(expected = "only a shift reads its right operand at a width of its own")]
+fn a_comparison_refuses_two_widths() {
+    // `compare` reads a width off each operand rather than being handed one for both, which is
+    // what makes this a check rather than a convention -- and it is a live question, because
+    // HLSSA's `Cmp` typing rule does not require equal widths and the instrumenter's own
+    // comparison decides one.
+    let _ = pat(8, 1).compare(CmpOp::ULt, &pat(16, 1));
 }
 
 #[test]
 fn bit_level_helpers_agree_with_their_definitions() {
-    assert_eq!(cast_int(0x1FF, 8), 0xFF);
+    // Each operand states the width it came from, which is what these helpers read: the width
+    // `sign_extend` extends *from* is the operand's own rather than a second opinion beside it.
+    assert_eq!(host(&pat(9, 0x1FF).cast(8)), 0xFF);
     assert_eq!(
-        cast_int(0xFF, 32),
+        host(&pat(8, 0xFF).cast(32)),
         0xFF,
         "widening a raw pattern zero-extends"
     );
     assert_eq!(
-        sign_extend(0xFF, 8, 32),
+        host(&pat(8, 0xFF).sign_extend(32)),
         0xFFFF_FFFF,
         "widening a signed one does not"
     );
-    assert_eq!(sign_extend(0x7F, 8, 32), 0x7F);
-    assert_eq!(bit_range(0xABCD, 8, 8), 0xAB);
-    assert_eq!(bit_range(0xABCD, 0, 8), 0xCD);
-    assert_eq!(not(0xF0, 8), 0x0F);
-    assert_eq!(decode_signed(8, 0xFF), -1);
+    assert_eq!(host(&pat(8, 0x7F).sign_extend(32)), 0x7F);
+    assert_eq!(host(&pat(16, 0xABCD).bit_range(8, 8)), 0xAB);
+    assert_eq!(host(&pat(16, 0xABCD).bit_range(0, 8)), 0xCD);
+    assert_eq!(host(&pat(8, 0xF0).complement()), 0x0F);
+    assert_eq!(pat(8, 0xFF).to_signed(), sv(-1));
     assert_eq!(
-        decode_signed(1, 1),
-        -1,
+        pat(1, 1).to_signed(),
+        sv(-1),
         "the only negative a one-bit pattern holds"
     );
-    assert_eq!(encode_signed(8, -1), 0xFF);
+    assert_eq!(enc(8, -1), 0xFF);
 }
 
 #[test]
-fn the_shift_backstop_masks_to_the_operand_width_not_the_host() {
-    // The clause that catches an evaluator inheriting a host width: `u128::wrapping_shl` masks to
-    // 127, so an evaluator built on it answers `1u8 << 8 == 0` where the VM and LLVM, which mask
-    // to `bits - 1`, answer `1`. `hlssa_to_r1cs::arith` is built on it today.
-    assert_eq!(masked_shift_amount(8, 8), 0);
-    assert_eq!(masked_shift_amount(100, 64), 36);
-    assert_eq!(residue(IntOp::Shl, Sign::Unsigned, 8, 1, 8, 8), Some(1));
-    assert_ne!(residue(IntOp::Shl, Sign::Unsigned, 8, 1, 8, 8), Some(0));
+fn the_host_word_mask_saturates_at_the_host_width_not_the_models_cap() {
+    // `mask` is the last host word in the model, and its saturating arm exists because
+    // `1u128 << bits` is a debug panic and a release build that silently masks the shift amount.
+    // The bound has to be the **host's** 128 rather than `MAX_BITS`, which the plan moves.
+    assert_eq!(mask(0), 0);
+    assert_eq!(mask(1), 1);
+    assert_eq!(mask(64), u128::from(u64::MAX));
+    assert_eq!(mask(127), u128::MAX >> 1);
+    assert_eq!(mask(128), u128::MAX);
 
-    // At a non-power-of-two width the mask is a submask rather than a modulo -- 9 & 6 is 0, not
-    // 9 % 7 == 2 -- and both backends compute that same submask, so the model records it.
-    assert_eq!(masked_shift_amount(9, 7), 0);
-    assert!(masked_shift_amount(u128::MAX, 7) < 7);
+    // The tripwire. Today `MAX_BITS` is 128 and these are the same assertion as the one above; the
+    // moment the cap moves they stop being, and a bound written against it would take the `<<` arm
+    // for a width no `u128` can express.
+    assert_eq!(mask(129), u128::MAX);
+    assert_eq!(mask(1000), u128::MAX);
+    assert_eq!(mask(MAX_BITS + 1), u128::MAX);
+}
+
+#[test]
+fn a_reading_outside_the_width_encodes_by_wrapping() {
+    // `IntBits::from_signed` is total, which it has to be for an unbounded `SignedValue`: an
+    // intermediate result legitimately leaves the width, and the answer is the low `bits` of its
+    // two's complement. That is a claim about `BigInt`'s bitwise operators reading a negative as
+    // two's complement extended indefinitely, so it is pinned rather than assumed.
+    assert_eq!(enc(8, 256), 0, "one whole turn is back where it started");
+    assert_eq!(enc(8, 257), 1);
+    assert_eq!(enc(8, -129), 0x7F, "one step past the bottom of the type");
+    assert_eq!(enc(8, -1000), u128::from(-1000i32 as u32 & 0xFF));
+    assert_eq!(enc(1, -1), 1, "the whole of a one-bit type");
+}
+
+#[test]
+fn the_signed_boundaries_are_total_at_every_width() {
+    // The two boundaries are pure powers of two and nothing caps them at `MAX_SIGNED_BITS`, so
+    // they are the first part of the model to reach the full width — and the part a host type
+    // could not have carried. `1i128 << 127` is not representable, which is what made the obvious
+    // spelling of the signed reading panic at width 127.
+    for bits in 1..=MAX_BITS {
+        let (min, max) = (IntBits::signed_min(bits), IntBits::signed_max(bits));
+        assert_eq!(
+            max.clone() + SignedValue::from(1u8),
+            -min.clone(),
+            "the top of a {bits}-bit type is one below the negated bottom"
+        );
+        assert_eq!(
+            max - min,
+            (SignedValue::from(1u8) << bits) - SignedValue::from(1u8),
+            "a {bits}-bit type spans 2^{bits} values"
+        );
+    }
+    assert_eq!(IntBits::signed_max(128), SignedValue::from(i128::MAX));
+    assert_eq!(IntBits::signed_min(128), SignedValue::from(i128::MIN));
+}
+
+#[test]
+fn the_shift_backstop_reduces_to_the_operand_width_not_the_host() {
+    // The clause that catches an evaluator inheriting a host width: `u128::wrapping_shl` masks to
+    // 127, so an evaluator built on it answers `1u8 << 8 == 0` where the VM and LLVM, which reduce
+    // by `bits`, answer `1`. `hlssa_to_r1cs::arith` avoids that by calling `residue` rather than
+    // shifting a host word itself, so this is the statement it relies on.
+    assert_eq!(reduced(8, 8), 0);
+    assert_eq!(reduced(100, 64), 36);
+    assert_eq!(
+        res(IntOp::Shl, 8, 1, 8, 8),
+        Some(1),
+        "reducing by the operand width, not by the host's"
+    );
+
+    // At a non-power-of-two width a mask is a submask rather than a modulo: `9 & 6` is `0`, which
+    // is not even the amount `9` reduces to. The modulo answers `9 % 7 == 2`, and an in-range
+    // amount is left exactly alone.
+    assert_eq!(reduced(9, 7), 2);
+    assert_eq!(reduced(1, 7), 1, "an in-range amount is untouched");
+    assert!(reduced(u128::MAX, 7) < 7);
+
+    // Every width, not only the powers of two: an amount already below the width survives.
+    for bits in 1..=MAX_BITS {
+        for amount in 0..bits {
+            assert_eq!(
+                reduced(amount as u128, bits),
+                amount as u32,
+                "an in-range amount must be left alone at {bits} bits"
+            );
+        }
+    }
 }
 
 // LAYER 2: EXHAUSTIVE
@@ -398,23 +719,28 @@ fn the_shift_backstop_masks_to_the_operand_width_not_the_host() {
 
 /// The invariant that makes the two-function split safe: a residue never contradicts an accepted
 /// evaluation, it only extends it into the rejected region.
-fn check_point(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs_bits: usize, rhs: Raw) {
-    let outcome = eval(op, sign, bits, lhs, rhs_bits, rhs);
-    let residue = residue(op, sign, bits, lhs, rhs_bits, rhs);
+fn check_point(op: IntOp, bits: usize, lhs: u128, rhs_bits: usize, rhs: u128) {
+    let outcome = eval(op, &pat(bits, lhs), &pat(rhs_bits, rhs));
+    let residue = res(op, bits, lhs, rhs_bits, rhs);
 
-    if let Outcome::Value(v) = outcome {
-        assert!(
-            v <= mask(bits),
-            "{op:?}/{sign:?}/{bits} produced {v:#x}, outside its width, from {lhs:#x} {rhs:#x}"
+    if let Outcome::Value(v) = &outcome {
+        // "Inside its width" is a statement about the answer's _declared_ width rather than about
+        // its magnitude: a pattern cannot carry a bit above the width it says it has, so what is
+        // left to check is that the model answers at the width it was asked at.
+        assert_eq!(
+            v.bits(),
+            bits,
+            "{op:?}/{bits} answered at width {} instead, from {lhs:#x} {rhs:#x}",
+            v.bits()
         );
         assert_eq!(
             residue,
-            Some(v),
-            "{op:?}/{sign:?}/{bits} residue contradicts its own accepted value"
+            Some(host(v)),
+            "{op:?}/{bits} residue contradicts its own accepted value"
         );
-        if sign.is_signed() {
+        if op.is_signed() {
             assert!(
-                fits_signed(bits, decode_signed(bits, v)),
+                IntBits::fits_signed(bits, &v.to_signed()),
                 "{op:?}/{bits} produced a pattern that does not decode into its own width"
             );
         }
@@ -423,7 +749,7 @@ fn check_point(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs_bits: usize, rh
     if let Some(r) = residue {
         assert!(
             r <= mask(bits),
-            "{op:?}/{sign:?}/{bits} residue {r:#x} escaped its width"
+            "{op:?}/{bits} residue {r:#x} escaped its width"
         );
     }
 
@@ -435,7 +761,7 @@ fn check_point(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs_bits: usize, rh
                 outcome,
                 Outcome::Rejected(Reject::DivByZero | Reject::DivOverflow)
             ),
-            "{op:?}/{sign:?}/{bits} left the residue unspecified for {outcome:?}"
+            "{op:?}/{bits} left the residue unspecified for {outcome:?}"
         );
     }
 }
@@ -444,15 +770,13 @@ fn check_point(op: IntOp, sign: Sign, bits: usize, lhs: Raw, rhs_bits: usize, rh
 fn every_operand_pair_at_narrow_widths() {
     for bits in corners::EXHAUSTIVE_WIDTHS {
         let m = mask(bits);
-        for sign in Sign::ALL {
-            if sign.is_signed() && !corners::signed_width_ok(bits) {
+        for op in IntOp::ALL {
+            if op.is_signed() && !corners::signed_width_ok(bits) {
                 continue;
             }
-            for op in IntOp::ALL {
-                for lhs in 0..=m {
-                    for rhs in 0..=m {
-                        check_point(op, sign, bits, lhs, bits, rhs);
-                    }
+            for lhs in 0..=m {
+                for rhs in 0..=m {
+                    check_point(op, bits, lhs, bits, rhs);
                 }
             }
         }
@@ -461,14 +785,12 @@ fn every_operand_pair_at_narrow_widths() {
 
 #[test]
 fn the_corner_cross_product_at_every_width() {
-    for sign in Sign::ALL {
-        for &bits in corners::widths_for(sign.is_signed()) {
+    for op in IntOp::ALL {
+        for &bits in corners::widths_for(op.is_signed()) {
             let vals = corners::values(bits);
-            for op in IntOp::ALL {
-                for &lhs in &vals {
-                    for &rhs in &vals {
-                        check_point(op, sign, bits, lhs, bits, rhs);
-                    }
+            for &lhs in &vals {
+                for &rhs in &vals {
+                    check_point(op, bits, lhs, bits, rhs);
                 }
             }
         }
@@ -477,15 +799,13 @@ fn the_corner_cross_product_at_every_width() {
 
 #[test]
 fn shifts_across_mixed_operand_widths() {
-    for sign in Sign::ALL {
-        for (bits, rhs_bits) in corners::shift_width_pairs(sign.is_signed()) {
+    for op in [IntOp::Shl, IntOp::UShr, IntOp::SShr] {
+        for (bits, rhs_bits) in corners::shift_width_pairs(op.is_signed()) {
             let vals = corners::values(bits);
             let amounts = corners::shift_amounts(bits, rhs_bits);
-            for op in [IntOp::Shl, IntOp::Shr] {
-                for &lhs in &vals {
-                    for &rhs in &amounts {
-                        check_point(op, sign, bits, lhs, rhs_bits, rhs);
-                    }
+            for &lhs in &vals {
+                for &rhs in &amounts {
+                    check_point(op, bits, lhs, rhs_bits, rhs);
                 }
             }
         }
@@ -497,22 +817,20 @@ fn the_accept_boundary_is_exactly_the_width() {
     // Swept rather than spot-checked: for every width, every amount below it is accepted and every
     // amount from it up to the representable maximum is rejected. An off-by-one anywhere in the
     // model or in an evaluator conforming to it shows up here as a single flipped point.
-    for sign in Sign::ALL {
-        for &bits in corners::widths_for(sign.is_signed()) {
-            for op in [IntOp::Shl, IntOp::Shr] {
-                for amount in 0..bits {
-                    assert!(
-                        !eval(op, sign, bits, 1, MAX_BITS, amount as u128).is_rejected(),
-                        "{op:?}/{sign:?}/{bits} rejected a legal amount {amount}"
-                    );
-                }
-                for amount in bits..=(bits + 2).min(MAX_BITS) {
-                    assert_eq!(
-                        eval(op, sign, bits, 1, MAX_BITS, amount as u128),
-                        Outcome::Rejected(Reject::ShiftAmount),
-                        "{op:?}/{sign:?}/{bits} accepted an illegal amount {amount}"
-                    );
-                }
+    for op in [IntOp::Shl, IntOp::UShr, IntOp::SShr] {
+        for &bits in corners::widths_for(op.is_signed()) {
+            for amount in 0..bits {
+                assert!(
+                    !eval(op, &pat(bits, 1), &pat(MAX_BITS, amount as u128)).is_rejected(),
+                    "{op:?}/{bits} rejected a legal amount {amount}"
+                );
+            }
+            for amount in bits..=(bits + 2).min(MAX_BITS) {
+                assert_eq!(
+                    eval(op, &pat(bits, 1), &pat(MAX_BITS, amount as u128)),
+                    Outcome::Rejected(Reject::ShiftAmount),
+                    "{op:?}/{bits} accepted an illegal amount {amount}"
+                );
             }
         }
     }
@@ -524,12 +842,10 @@ fn odd_widths_are_swept_too() {
     // the width is a power of two, so the model has to have a defined answer to compare them
     // against when one of them stops assuming it.
     for &bits in &corners::ODD_WIDTHS {
-        for sign in Sign::ALL {
-            for op in IntOp::ALL {
-                for &lhs in &corners::values(bits) {
-                    for &rhs in &corners::values(bits) {
-                        check_point(op, sign, bits, lhs, bits, rhs);
-                    }
+        for op in IntOp::ALL {
+            for &lhs in &corners::values(bits) {
+                for &rhs in &corners::values(bits) {
+                    check_point(op, bits, lhs, bits, rhs);
                 }
             }
         }
@@ -549,8 +865,27 @@ fn width_and_value(max_bits: usize) -> impl Strategy<Value = (usize, u128)> {
     })
 }
 
-fn any_op() -> impl Strategy<Value = IntOp> {
-    prop::sample::select(IntOp::ALL.to_vec())
+/// Any operation whose reading is not signed, so the sweep may use the full width range.
+///
+/// The reading-free operations belong here rather than being dropped: `And` at 128 bits is
+/// perfectly legal and is the case the unsigned sweep is for.
+fn any_unsigned_op() -> impl Strategy<Value = IntOp> {
+    prop::sample::select(
+        IntOp::ALL
+            .into_iter()
+            .filter(|op| !op.is_signed())
+            .collect::<Vec<_>>(),
+    )
+}
+
+/// Any operation that reads its operands as two's complement.
+fn any_signed_op() -> impl Strategy<Value = IntOp> {
+    prop::sample::select(
+        IntOp::ALL
+            .into_iter()
+            .filter(|op| op.is_signed())
+            .collect::<Vec<_>>(),
+    )
 }
 
 proptest! {
@@ -560,18 +895,18 @@ proptest! {
     fn model_invariants_hold_anywhere_unsigned(
         (bits, lhs) in width_and_value(MAX_BITS),
         rhs in any::<u128>(),
-        op in any_op(),
+        op in any_unsigned_op(),
     ) {
-        check_point(op, Sign::Unsigned, bits, lhs, bits, rhs & mask(bits));
+        check_point(op, bits, lhs, bits, rhs & mask(bits));
     }
 
     #[test]
     fn model_invariants_hold_anywhere_signed(
         (bits, lhs) in width_and_value(MAX_SIGNED_BITS),
         rhs in any::<u128>(),
-        op in any_op(),
+        op in any_signed_op(),
     ) {
-        check_point(op, Sign::Signed, bits, lhs, bits, rhs & mask(bits));
+        check_point(op, bits, lhs, bits, rhs & mask(bits));
     }
 
     /// Mixed operand widths, which the hand-written pairs cannot enumerate.
@@ -581,17 +916,17 @@ proptest! {
         (rhs_bits, rhs) in width_and_value(MAX_BITS),
         shl in any::<bool>(),
     ) {
-        let op = if shl { IntOp::Shl } else { IntOp::Shr };
-        check_point(op, Sign::Unsigned, bits, lhs, rhs_bits, rhs);
+        let op = if shl { IntOp::Shl } else { IntOp::UShr };
+        check_point(op, bits, lhs, rhs_bits, rhs);
     }
 
     /// Two's complement round-trips, which everything signed rests on.
     #[test]
     fn signed_encoding_round_trips((bits, raw) in width_and_value(MAX_SIGNED_BITS)) {
-        let decoded = decode_signed(bits, raw);
-        prop_assert!(fits_signed(bits, decoded));
-        prop_assert_eq!(encode_signed(bits, decoded), raw);
-        prop_assert!(decoded >= signed_min(bits) && decoded <= signed_max(bits));
+        let decoded = pat(bits, raw).to_signed();
+        prop_assert!(IntBits::fits_signed(bits, &decoded));
+        prop_assert_eq!(host(&IntBits::from_signed(bits, &decoded)), raw);
+        prop_assert!(decoded >= IntBits::signed_min(bits) && decoded <= IntBits::signed_max(bits));
     }
 
     /// An accepted signed result is exactly a result that fits, and a rejected one is exactly one
@@ -602,14 +937,14 @@ proptest! {
         rhs in any::<u128>(),
     ) {
         let rhs = rhs & mask(bits);
-        let sum = decode_signed(bits, lhs) + decode_signed(bits, rhs);
-        match eval(IntOp::Add, Sign::Signed, bits, lhs, bits, rhs) {
+        let sum = pat(bits, lhs).to_signed() + pat(bits, rhs).to_signed();
+        match ev(IntOp::SAdd, bits, lhs, rhs) {
             Outcome::Value(v) => {
-                prop_assert!(fits_signed(bits, sum));
-                prop_assert_eq!(decode_signed(bits, v), sum);
+                prop_assert!(IntBits::fits_signed(bits, &sum));
+                prop_assert_eq!(v.to_signed(), sum);
             }
             Outcome::Rejected(r) => {
-                prop_assert!(!fits_signed(bits, sum));
+                prop_assert!(!IntBits::fits_signed(bits, &sum));
                 prop_assert_eq!(r, Reject::Overflow);
             }
         }
@@ -622,8 +957,10 @@ proptest! {
         amount in any::<u128>(),
         shl in any::<bool>(),
     ) {
-        let op = if shl { IntOp::Shl } else { IntOp::Shr };
-        let rejected = eval(op, Sign::Unsigned, bits, lhs, MAX_BITS, amount).is_rejected();
+        let op = if shl { IntOp::Shl } else { IntOp::UShr };
+        let rejected =
+            eval(op, &pat(bits, lhs), &pat(MAX_BITS, amount))
+                .is_rejected();
         prop_assert_eq!(rejected, amount >= bits as u128);
     }
 
@@ -631,11 +968,11 @@ proptest! {
     #[test]
     fn comparison_matches_its_reading((bits, lhs) in width_and_value(MAX_SIGNED_BITS), rhs in any::<u128>()) {
         let rhs = rhs & mask(bits);
-        prop_assert_eq!(cmp(CmpOp::Lt, Sign::Unsigned, bits, lhs, rhs), lhs < rhs);
+        prop_assert_eq!(compare(CmpOp::ULt, bits, lhs, rhs), lhs < rhs);
         prop_assert_eq!(
-            cmp(CmpOp::Lt, Sign::Signed, bits, lhs, rhs),
-            decode_signed(bits, lhs) < decode_signed(bits, rhs)
+            compare(CmpOp::SLt, bits, lhs, rhs),
+            pat(bits, lhs).to_signed() < pat(bits, rhs).to_signed()
         );
-        prop_assert_eq!(cmp(CmpOp::Eq, Sign::Unsigned, bits, lhs, rhs), lhs == rhs);
+        prop_assert_eq!(compare(CmpOp::Eq, bits, lhs, rhs), lhs == rhs);
     }
 }

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -332,33 +332,48 @@ fn cell_mask(bits: u64) -> u64 {
 
 /// The amount a `bits`-wide shift actually applies, given a requested amount of `b`.
 ///
-/// Masked to `bits - 1`. It matches the LLVM backend, which masks to the LLVM type's `bit_width - 1`
-/// (`llssa_to_llvm.rs`, both shift arms) because LLVM treats a shift at or past the width as
+/// Reduced modulo `bits`. It matches the LLVM backend, which reduces by the LLVM type's own width
+/// (`llssa_to_llvm.rs::reduce_shift_count`) because LLVM treats a shift at or past the width as
 /// poison. It also keeps the count in range for Rust's shift operators, which panic on an
 /// over-shift in a debug build and mask to the *host* width (`b & 63`) in release, a divergence
 /// that is wrong for any `bits < 64`.
 ///
-/// The result is below `bits` at **every** width, not only the powers of two: `b & (bits - 1)` is a
-/// submask of `bits - 1`, so it can never exceed it. That is what makes this safe as a blanket
-/// backstop rather than only where the width happens to make the mask a modulo.
+/// It is a **modulo, not a mask**. At a power-of-two width the two coincide, so at every width Noir
+/// can name this answers exactly what `b & (bits - 1)` does. At a width that is not a power of two
+/// they differ, and the mask is the wrong one of the pair: it stays below `bits`, which is all a
+/// backstop needs, but it corrupts amounts that were already _in range_ — at `bits == 7` a mask
+/// turns an amount of `1` into `0`, while `hlssa_to_r1cs` applies that same `1` literally. The
+/// modulo is what makes the three evaluators agree at every width.
 ///
-/// A well-formed program never reaches the mask. Both routes to a shift reject an out-of-range
-/// amount before the opcode runs: `pure_guards`' shift-amount check for a pure amount, and
-/// `witness_bitwise::emit_shift_amount_check` for a witness one. This is the backstop for when
-/// they do not.
+/// The power-of-two arm is a fast path, not a second semantics: `bits` arrives as an opcode
+/// immediate, so the branch is decided by the instruction rather than by data.
 ///
-/// `bits == 0` saturates to a mask of zero rather than underflowing to `u64::MAX`. A zero-width
-/// cell holds nothing — `cell_mask(0)` is `0` — so every shift of one answers `0` whatever the
-/// amount, and stops the amount reaching the host shift and panicking.
+/// A well-formed program never reaches the reduction. Both routes to a shift reject an
+/// out-of-range amount before the opcode runs: `pure_guards`' shift-amount check for a pure
+/// amount, and `witness_bitwise::emit_shift_amount_check` for a witness one. This is the backstop
+/// for when they do not.
+///
+/// `bits == 0` answers `0` rather than dividing by zero. A zero-width cell holds nothing —
+/// `cell_mask(0)` is `0` — so every shift of one answers `0` whatever the amount, and this stops
+/// the amount reaching the host shift and panicking.
 #[inline(always)]
 fn shift_amount(b: u64, bits: u64) -> u32 {
-    (b & bits.saturating_sub(1)) as u32
+    if bits == 0 {
+        return 0;
+    }
+    if bits.is_power_of_two() {
+        (b & (bits - 1)) as u32
+    } else {
+        (b % bits) as u32
+    }
 }
 
 /// The amount a 128-bit shift actually applies, given a requested amount of `b`.
 ///
 /// The `_int` lane's [`shift_amount`] takes its width as a parameter because a cell is wider than
-/// the value in it; here the width _is_ the lane, so the mask is the constant `127`.
+/// the value in it; here the width _is_ the lane, so the reduction is the constant `127`. `128` is
+/// a power of two, so masking by `127` _is_ the `b % 128` that [`shift_amount`] would compute, and
+/// this lane needs no modulo arm of its own.
 ///
 /// Only `b.lo` is read, and the high limb is not a lost check: LLVM masks the whole 128-bit amount
 /// with `bit_width - 1 == 127` (`llssa_to_llvm.rs`, both shift arms), and the low seven bits of a
@@ -1312,8 +1327,8 @@ unsafe fn ad_kv_lookup_emit(
 ///   the VM does not trap: overflow rejection is guard IR emitted before codegen. See
 ///   `BinaryArithOpKind`'s doc.)
 /// - **The suffix is the lane, not a reading**: `_int` is one 64-bit cell (widths 1..=64),
-///   `_int128` is two, `_field` is four. It used to be `_u64`/`_u128`, which named the host storage
-///   and then lied about the reading — most loudly in `ashr_u64`, the *signed* right shift.
+///   `_int128` is two, `_field` is four. Naming the host storage instead (`_u64`/`_u128`) would
+///   lie about the reading — most loudly for `ashr_int`, the *signed* right shift.
 /// - **`bits` is the width and nothing else.** It is never a signedness marker. An opcode takes it
 ///   exactly when its *result* depends on it: to re-mask an output that can exceed the width
 ///   (`add_int`, `sub_int`, `mul_int`, `shl_int`, `not_int`), to mask a shift amount, or to locate
@@ -1321,9 +1336,9 @@ unsafe fn ad_kv_lookup_emit(
 ///   are correct on any two already-masked operands — `and_int`, `or_int`, `xor_int`, `eq_int`,
 ///   `ult_int`, `udiv_int`, `urem_int` — take no width and must not grow one.
 ///
-/// That last rule is what keeps `bits` from reading as the flag it used to look like: `sdiv_int`
-/// carries it and `udiv_int` does not, but the reason is that the signed form needs to know where
-/// the sign bit *is*, which is a fact about the encoding rather than a fact about the operation.
+/// That last rule is what keeps `bits` from reading as a signedness flag: `sdiv_int` carries it
+/// and `udiv_int` does not, but the reason is that the signed form needs to know where the sign
+/// bit *is*, which is a fact about the encoding rather than a fact about the operation.
 ///
 /// The `_int128` lane has no signed member at all, which is what
 /// `hlssa::type_system::MAX_SUPPORTED_SIGNED_BITS = 64` exists to enforce.
@@ -1613,9 +1628,9 @@ mod def {
     /// before shifting — sign-extend to `i64`, shift there, then re-mask. That is the same
     /// `signed_cell` preamble `sdiv_int`/`srem_int`/`slt_int` use.
     ///
-    /// The shift count is masked to `bits - 1` to match what the LLVM backend does for this op
-    /// (`llssa_to_llvm.rs`, which masks to the LLVM type's `bit_width - 1`), so an over-shift
-    /// cannot make the two backends disagree — and cannot panic on the `i64` shift.
+    /// The shift count is reduced modulo `bits` to match what the LLVM backend does for this op
+    /// (`llssa_to_llvm::reduce_shift_count`), so an over-shift cannot make the two backends disagree
+    /// — and cannot panic on the `i64` shift.
     #[opcode]
     fn ashr_int(#[out] res: *mut u64, #[frame] a: u64, #[frame] b: u64, bits: u64) {
         unsafe {
@@ -3555,7 +3570,7 @@ mod tests {
         assert_eq!(table_row_index(low_limb_in_range, 8), None);
 
         // The same shape at the top of the field: `-1` truncates to an arbitrary `u64`, which is
-        // the case that used to land outside the multiplicities buffer entirely.
+        // the case that would land outside the multiplicities buffer entirely if it were taken.
         assert_eq!(table_row_index(-Field::from(1u64), 8), None);
     }
 
@@ -3600,19 +3615,29 @@ mod tests {
     }
 
     #[test]
-    fn a_shift_amount_is_masked_to_the_operand_width() {
+    fn a_shift_amount_is_reduced_to_the_operand_width() {
         // In range: the amount passes through untouched.
         assert_eq!(shift_amount(0, 8), 0);
         assert_eq!(shift_amount(7, 8), 7);
         assert_eq!(shift_amount(63, 64), 63);
 
-        // Out of range: masked to `bits - 1`, which is what LLVM does with the same operands
-        // (`llssa_to_llvm.rs` ands the count with `bit_width - 1` on both shift arms). Before this
-        // was shared, `shl_int` and `ushr_int` used the raw amount and disagreed with LLVM here.
+        // Out of range: reduced modulo the width, which is what LLVM does with the same operands
+        // (`llssa_to_llvm::reduce_shift_count`). Every shift opcode routes its amount through here
+        // rather than using it raw, which is what keeps the two backends agreeing.
         assert_eq!(shift_amount(8, 8), 0);
         assert_eq!(shift_amount(9, 8), 1);
         assert_eq!(shift_amount(64, 64), 0);
         assert_eq!(shift_amount(65, 64), 1);
+
+        // At a non-power-of-two width a mask and a modulo part company, and only the modulo leaves
+        // an in-range amount alone. A mask by `bits - 1 == 6` would answer `0` for both of these.
+        assert_eq!(shift_amount(1, 7), 1);
+        assert_eq!(shift_amount(8, 7), 1);
+        assert_eq!(
+            shift_amount(6, 7),
+            6,
+            "the largest legal amount at seven bits"
+        );
     }
 
     #[test]
@@ -3633,15 +3658,19 @@ mod tests {
     }
 
     #[test]
-    fn an_over_shift_masks_rather_than_panicking() {
+    fn an_over_shift_reduces_rather_than_panicking() {
         // The whole point of routing the amount through `shift_amount`: a bare `a << b` panics in
         // a debug build for `b >= 64` and is silently `b & 63` in release, which is the wrong
         // answer for every width below 64. Both directions, through the opcode bodies themselves.
         let a = 0xABu64;
-        assert_eq!(cell_shl(a, 8, 8), a, "an 8-bit `<<` by 8 masks to `<< 0`");
-        assert_eq!(cell_ushr(a, 8, 8), a, "an 8-bit `>>` by 8 masks to `>> 0`");
+        assert_eq!(cell_shl(a, 8, 8), a, "an 8-bit `<<` by 8 reduces to `<< 0`");
+        assert_eq!(
+            cell_ushr(a, 8, 8),
+            a,
+            "an 8-bit `>>` by 8 reduces to `>> 0`"
+        );
 
-        // An amount past the *host* width too, which is where the debug panic used to fire.
+        // An amount past the *host* width too, which is where a bare `a << b` panics in debug.
         assert_eq!(cell_shl(a, 200, 8), a);
         assert_eq!(cell_ushr(a, 200, 8), a);
         assert_eq!(cell_ashr(a, 200, 8), a);
@@ -3744,8 +3773,8 @@ mod tests {
 
     #[test]
     fn a_zero_width_shift_answers_rather_than_panicking() {
-        // `bits - 1` used to underflow to `u64::MAX` here, so the amount reached the host shift
-        // unmasked. A zero-width cell holds nothing, so zero is the only answer available.
+        // A width of zero must not reach the host shift unreduced -- and `bits - 1` would
+        // underflow to `u64::MAX`. A zero-width cell holds nothing, so zero is the only answer.
         assert_eq!(shift_amount(u64::MAX, 0), 0);
         assert_eq!(cell_shl(0, u64::MAX, 0), 0);
         assert_eq!(cell_ushr(0, u64::MAX, 0), 0);
@@ -3770,8 +3799,8 @@ mod tests {
         );
 
         // `INT_MIN / -1` is the other input the host aborts on, and only at the host's own width:
-        // below 64 the `i64` division succeeds and the mask brings it back, which is the wrapping
-        // this now extends to 64 rather than a new behaviour.
+        // below 64 the `i64` division succeeds and the mask brings it back, and the 64-bit case
+        // is held to that same wrapping rather than to the host's abort.
         assert_eq!(
             cell_sdiv(0x80, 0xFF, 8),
             0x80,
@@ -3836,7 +3865,8 @@ mod tests {
         assert_eq!(cell_complement(0, 64), u64::MAX);
 
         // Agrees with the constant folder, `click_cooper::lattice::eval_not`, which is
-        // `!x & bit_mask(bits)`. The two used to disagree for every width below 64.
+        // `!x & bit_mask(bits)`. Complementing without re-masking would disagree with it at every
+        // width below 64.
         for bits in [1u64, 8, 32, 64] {
             for a in [0u64, 1, 0x5A, u64::MAX] {
                 let a = a & cell_mask(bits);
@@ -3869,34 +3899,23 @@ mod tests {
 /// which is what makes those inputs safe rather than merely unspecified.
 #[cfg(test)]
 mod int_semantics_conformance {
-    use mavros_int_semantics::{CmpOp, IntOp, Raw, Sign, corners, residue};
+    use mavros_int_semantics::{CmpOp, IntBits, IntOp, Sign, corners, residue};
 
     use super::*;
 
     /// Every width the `_int` lane can hold, including the non-powers of two.
     ///
-    /// The odd widths are here because everything but a shift is width-generic in both the VM and
-    /// the model: these bodies take `bits` and mask by it, so nothing about them is specific to the
-    /// five widths Noir can name.
+    /// The odd widths are here because these bodies are width-generic in both the VM and the
+    /// model: they take `bits` and mask by it, so nothing about them is specific to the five
+    /// widths Noir can name. Shifts share the set: `shift_amount` reduces the amount modulo the
+    /// width rather than masking it by `bits - 1`, which is the model's reduction at every width
+    /// and not only at a power of two.
     fn lane_widths(sign: Sign) -> Vec<u64> {
         corners::widths_for(sign.is_signed())
             .iter()
             .copied()
-            .chain(corners::ODD_WIDTHS)
             .filter(|bits| *bits <= 64)
             .map(|bits| bits as u64)
-            .collect()
-    }
-
-    /// The widths a **shift** is swept at: [`lane_widths`] without the non-powers of two.
-    ///
-    /// A shift is the one operation these bodies are _not_ width-generic in: `shift_amount` masks
-    /// by `bits - 1`, which is the model's `masked_shift_amount` only at a power-of-two width. The
-    /// compiler holds up its end of that at `shift_guard::shift_operand_bits`.
-    fn shift_widths(sign: Sign) -> Vec<u64> {
-        lane_widths(sign)
-            .into_iter()
-            .filter(|bits| bits.is_power_of_two())
             .collect()
     }
 
@@ -3905,24 +3924,28 @@ mod int_semantics_conformance {
     /// This is the dispatch `bytecode/mod.rs` performs when it picks a `BinaryArithOp`, written out
     /// so the conformance sweep exercises the same bodies the interpreter does without going
     /// through the dispatch loop.
-    fn int_lane(op: IntOp, sign: Sign, bits: u64, a: u64, b: u64) -> u64 {
-        match (op, sign) {
-            (IntOp::Add, _) => cell_add(a, b, bits),
-            (IntOp::Sub, _) => cell_sub(a, b, bits),
-            (IntOp::Mul, _) => cell_mul(a, b, bits),
-            (IntOp::Div, Sign::Unsigned) => cell_udiv(a, b),
-            (IntOp::Div, Sign::Signed) => cell_sdiv(a, b, bits),
-            (IntOp::Rem, Sign::Unsigned) => cell_urem(a, b),
-            (IntOp::Rem, Sign::Signed) => cell_srem(a, b, bits),
-            (IntOp::And, _) => cell_and(a, b),
-            (IntOp::Or, _) => cell_or(a, b),
-            (IntOp::Xor, _) => cell_xor(a, b),
+    fn int_lane(op: IntOp, bits: u64, a: u64, b: u64) -> u64 {
+        match op {
+            // Add, sub and mul come in a signed pair in the model because they differ in *when they
+            // fail*. By the time an opcode runs the guard IR has already decided. So both members
+            // map to one body here, which is the same reason `residue` and not `eval` is what this
+            // lane is held to.
+            IntOp::UAdd | IntOp::SAdd => cell_add(a, b, bits),
+            IntOp::USub | IntOp::SSub => cell_sub(a, b, bits),
+            IntOp::UMul | IntOp::SMul => cell_mul(a, b, bits),
+            IntOp::UDiv => cell_udiv(a, b),
+            IntOp::SDiv => cell_sdiv(a, b, bits),
+            IntOp::URem => cell_urem(a, b),
+            IntOp::SRem => cell_srem(a, b, bits),
+            IntOp::And => cell_and(a, b),
+            IntOp::Or => cell_or(a, b),
+            IntOp::Xor => cell_xor(a, b),
             // A left shift is one map on the bit pattern, so there is no signed form to dispatch
             // to; what a signed `<<` additionally rejects is a negative amount, and that rejection
-            // is guard IR's rather than an opcode's.
-            (IntOp::Shl, _) => cell_shl(a, b, bits),
-            (IntOp::Shr, Sign::Unsigned) => cell_ushr(a, b, bits),
-            (IntOp::Shr, Sign::Signed) => cell_ashr(a, b, bits),
+            // is guard IR's rather than an opcode's. The model has one `Shl` for the same reason.
+            IntOp::Shl => cell_shl(a, b, bits),
+            IntOp::UShr => cell_ushr(a, b, bits),
+            IntOp::SShr => cell_ashr(a, b, bits),
         }
     }
 
@@ -3933,16 +3956,21 @@ mod int_semantics_conformance {
     /// is why there is no `ashr_int128` or `sdiv_int128` to call.
     fn int128_lane(op: IntOp, a: Int128, b: Int128) -> Int128 {
         match op {
-            IntOp::Add => a.wrapping_add(b),
-            IntOp::Sub => a.wrapping_sub(b),
-            IntOp::Mul => a.wrapping_mul(b),
-            IntOp::Div => a.unsigned_div(b),
-            IntOp::Rem => a.unsigned_rem(b),
+            IntOp::UAdd => a.wrapping_add(b),
+            IntOp::USub => a.wrapping_sub(b),
+            IntOp::UMul => a.wrapping_mul(b),
+            IntOp::UDiv => a.unsigned_div(b),
+            IntOp::URem => a.unsigned_rem(b),
             IntOp::And => a & b,
             IntOp::Or => a | b,
             IntOp::Xor => a ^ b,
             IntOp::Shl => a.wrapping_shl(shift_amount_128(b)),
-            IntOp::Shr => a.wrapping_shr(shift_amount_128(b)),
+            IntOp::UShr => a.wrapping_shr(shift_amount_128(b)),
+            // The signed forms have no 128-bit opcode to sweep, which the caller enforces by
+            // sweeping this lane unsigned; naming them here keeps a new variant a compile error.
+            IntOp::SAdd | IntOp::SSub | IntOp::SMul | IntOp::SDiv | IntOp::SRem | IntOp::SShr => {
+                unreachable!("{op:?} has no 128-bit lane: MAX_SUPPORTED_SIGNED_BITS is 64")
+            }
         }
     }
 
@@ -3955,8 +3983,8 @@ mod int_semantics_conformance {
     /// elaborator unifies the two operands of an infix operator, shifts included, so `bits` is also
     /// the amount's width for anything the frontend produces. It is also the only case the VM can
     /// distinguish.
-    fn operand_pairs(op: IntOp, bits: usize) -> Vec<(Raw, Raw)> {
-        let rhs = if matches!(op, IntOp::Shl | IntOp::Shr) {
+    fn operand_pairs(op: IntOp, bits: usize) -> Vec<(u128, u128)> {
+        let rhs = if op.is_shift() {
             corners::shift_amounts(bits, bits)
         } else {
             corners::values(bits)
@@ -3967,42 +3995,67 @@ mod int_semantics_conformance {
             .collect()
     }
 
+    /// The host word a model answer denotes.
+    ///
+    /// The VM holds its integers in `u64` frame cells and this sweep compares cells, so a pattern
+    /// exists only for the length of a call into the model. It is the one evaluator whose value
+    /// domain _is_ the machine's, which is why it carries no `IntBits` of its own.
+    fn host(value: &IntBits) -> u128 {
+        u128::try_from(value).expect("a pattern no wider than MAX_BITS fits a host word")
+    }
+
+    /// `residue` on the host words either side of it.
+    fn model(op: IntOp, bits: usize, a: u128, rhs_bits: usize, b: u128) -> Option<u128> {
+        residue(
+            op,
+            &IntBits::from_u128(bits, a),
+            &IntBits::from_u128(rhs_bits, b),
+        )
+        .map(|v| host(&v))
+    }
+
+    /// `IntBits::compare` on host words.
+    fn compare(op: CmpOp, bits: usize, a: u128, b: u128) -> bool {
+        IntBits::from_u128(bits, a).compare(op, &IntBits::from_u128(bits, b))
+    }
+
     #[test]
     fn the_int_lane_agrees_with_the_model() {
         let mut checked = 0usize;
 
-        for sign in Sign::ALL {
-            for op in IntOp::ALL {
-                let widths = if matches!(op, IntOp::Shl | IntOp::Shr) {
-                    shift_widths(sign)
-                } else {
-                    lane_widths(sign)
-                };
+        for op in IntOp::ALL {
+            // The reading is the operation's own, so the width set it admits comes off it rather
+            // than off a sign swept beside it. One set covers the shifts too — see `lane_widths`.
+            let sign = op.sign().unwrap_or(Sign::Unsigned);
+            let widths = lane_widths(sign);
 
-                for bits in widths {
-                    for (a, b) in operand_pairs(op, bits as usize) {
-                        let (a, b) = (a as u64, b as u64);
-                        let got = int_lane(op, sign, bits, a, b);
+            for bits in widths {
+                for (a, b) in operand_pairs(op, bits as usize) {
+                    let (a, b) = (a as u64, b as u64);
+                    let got = int_lane(op, bits, a, b);
 
-                        // Rule 3, which binds on every input including the unspecified ones.
+                    // Rule 3, which binds on every input including the unspecified ones.
+                    assert_eq!(
+                        got & !cell_mask(bits),
+                        0,
+                        "{op:?} at {bits} bits left {a:#x} {b:#x} outside the width: {got:#x}"
+                    );
+
+                    // Rule 1, where the model has an opinion.
+                    if let Some(want) = model(
+                        op,
+                        bits as usize,
+                        u128::from(a),
+                        bits as usize,
+                        u128::from(b),
+                    ) {
                         assert_eq!(
-                            got & !cell_mask(bits),
-                            0,
-                            "{op:?}/{sign:?} at {bits} bits left {a:#x} {b:#x} outside the width: \
-                             {got:#x}"
+                            u128::from(got),
+                            want,
+                            "{op:?} at {bits} bits: {a:#x} {b:#x} gave {got:#x}, \
+                             model says {want:#x}"
                         );
-
-                        // Rule 1, where the model has an opinion.
-                        if let Some(want) =
-                            residue(op, sign, bits as usize, a as Raw, bits as usize, b as Raw)
-                        {
-                            assert_eq!(
-                                got as Raw, want,
-                                "{op:?}/{sign:?} at {bits} bits: {a:#x} {b:#x} gave {got:#x}, \
-                                 model says {want:#x}"
-                            );
-                            checked += 1;
-                        }
+                        checked += 1;
                     }
                 }
             }
@@ -4020,11 +4073,14 @@ mod int_semantics_conformance {
     fn the_int128_lane_agrees_with_the_model() {
         let mut checked = 0usize;
 
-        for op in IntOp::ALL {
+        // Unsigned only: `MAX_SUPPORTED_SIGNED_BITS` is 64, so no signed opcode reads a pattern
+        // this wide and there is none to sweep. The filter is what the lane's own `unreachable!`
+        // arms rely on.
+        for op in IntOp::ALL.into_iter().filter(|op| !op.is_signed()) {
             for (a, b) in operand_pairs(op, 128) {
                 let got = int128_lane(op, Int128::from_u128(a), Int128::from_u128(b));
 
-                if let Some(want) = residue(op, Sign::Unsigned, 128, a, 128, b) {
+                if let Some(want) = model(op, 128, a, 128, b) {
                     assert_eq!(
                         got.to_u128(),
                         want,
@@ -4052,19 +4108,13 @@ mod int_semantics_conformance {
                     let (au, bu) = (a as u64, b as u64);
                     let at = bits as usize;
 
-                    assert_eq!(
-                        au == bu,
-                        mavros_int_semantics::cmp(CmpOp::Eq, Sign::Unsigned, at, a, b)
-                    );
-                    assert_eq!(
-                        au < bu,
-                        mavros_int_semantics::cmp(CmpOp::Lt, Sign::Unsigned, at, a, b)
-                    );
+                    assert_eq!(au == bu, compare(CmpOp::Eq, at, a, b));
+                    assert_eq!(au < bu, compare(CmpOp::ULt, at, a, b));
 
                     if corners::signed_width_ok(at) {
                         assert_eq!(
                             signed_cell(au, bits) < signed_cell(bu, bits),
-                            mavros_int_semantics::cmp(CmpOp::Lt, Sign::Signed, at, a, b),
+                            compare(CmpOp::SLt, at, a, b),
                             "slt_int disagreed at {bits} bits on {a:#x} {b:#x}"
                         );
                     }
@@ -4078,8 +4128,8 @@ mod int_semantics_conformance {
         for bits in lane_widths(Sign::Unsigned) {
             for a in corners::values(bits as usize) {
                 assert_eq!(
-                    cell_complement(a as u64, bits) as Raw,
-                    mavros_int_semantics::not(a, bits as usize),
+                    u128::from(cell_complement(a as u64, bits)),
+                    host(&IntBits::from_u128(bits as usize, a).complement()),
                     "not_int disagreed at {bits} bits on {a:#x}"
                 );
             }


### PR DESCRIPTION
The integer semantics model has been updated with the `IntBits` type, which serves as a centralized, data-carrying, computational model of the expected integer semantics in Mavros. It carries its own width, allowing it to perform additional validation at compile time.

The compiler has been swapped to use `IntBits` for carrying integer values wherever it does so, ensuring that computations on them are always evaluated correctly under the model, and that arbitrary-sized integers can be supported in future work without additional effort.

Partial work on #120 