### PR TITLE
Add a witness limb abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,7 @@ dependencies = [
 name = "mavros-int-semantics"
 version = "0.1.0"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "proptest",
  "thiserror 2.0.18",
 ]

--- a/compiler/src/compiler/analysis/instrumenter.rs
+++ b/compiler/src/compiler/analysis/instrumenter.rs
@@ -10,7 +10,7 @@ use std::{cell::RefCell, rc::Rc};
 use ark_ff::{BigInt, BigInteger};
 use itertools::Itertools;
 use mavros_artifacts::FieldConfig;
-use mavros_int_semantics::{self as semantics, CmpOp, IntBits};
+use mavros_int_semantics::{self as semantics, CmpOp, IntBits, int_bits::FIELD_LIMB_BITS};
 use num_bigint::BigUint;
 use tracing::{debug, instrument};
 
@@ -757,7 +757,7 @@ impl Value {
                     // Divide val by radix_val
                     let mut carry: u128 = 0;
                     for i in (0..val.0.len()).rev() {
-                        let cur = (carry << 64) | (val.0[i] as u128);
+                        let cur = (carry << FIELD_LIMB_BITS) | (val.0[i] as u128);
                         val.0[i] = (cur / radix_val) as u64;
                         carry = cur % radix_val;
                     }

--- a/compiler/src/compiler/codegen/bytecode/layout.rs
+++ b/compiler/src/compiler/codegen/bytecode/layout.rs
@@ -1,5 +1,7 @@
 //! Tools and utilities for computing layouts when generating bytecode.
 
+use mavros_int_semantics::IntBits;
+
 use crate::{
     collections::HashMap,
     compiler::{
@@ -280,9 +282,10 @@ impl GlobalFrameLayouter {
     }
 }
 
+/// The number of VM frame cells a `bits`-wide integer occupies.
 pub fn int_cell_count(bits: usize) -> usize {
-    assert!(bits > 0 && bits <= MAX_SUPPORTED_UNSIGNED_BITS);
-    bits.div_ceil(64)
+    assert!(bits <= MAX_SUPPORTED_UNSIGNED_BITS);
+    IntBits::limbs_for_bits(bits)
 }
 
 // TESTS

--- a/compiler/src/compiler/codegen/bytecode/mod.rs
+++ b/compiler/src/compiler/codegen/bytecode/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod layout;
 
+use mavros_int_semantics::int_bits::HOST_LIMB_BITS;
+
 use crate::{
     collections::HashMap,
     compiler::{
@@ -13,7 +15,7 @@ use crate::{
             CodeGenOptions,
             bytecode::layout::{
                 ConstantPoolInterner, FrameLayouter, GlobalFrameLayouter, StructLayoutInterner,
-                for_each_constant_word,
+                for_each_constant_word, int_cell_count,
             },
         },
         ssa::{
@@ -884,8 +886,8 @@ impl CodeGen {
                         (TypeExpr::Int(source_bits), TypeExpr::Int(target_bits))
                             if *source_bits <= 64 && *target_bits <= 64 =>
                         {
-                            let source_cells = source_bits.div_ceil(64);
-                            let target_cells = target_bits.div_ceil(64);
+                            let source_cells = int_cell_count(*source_bits);
+                            let target_cells = int_cell_count(*target_bits);
                             let copied_cells = source_cells.min(target_cells);
                             emitter.push_op(bytecode::OpCode::MovFrame {
                                 target: result,
@@ -909,12 +911,16 @@ impl CodeGen {
                             }
                         }
                         (TypeExpr::Int(128), TypeExpr::Int(target_bits)) if *target_bits <= 64 => {
+                            // The narrowing is a prefix copy, so unlike the arm above it needs no
+                            // `target_bits < source_bits` test: the cells it drops are the ones the
+                            // target does not have.
+                            let target_cells = int_cell_count(*target_bits);
                             emitter.push_op(bytecode::OpCode::MovFrame {
                                 target: result,
                                 source: layouter.get_value(*v),
-                                size: 1,
+                                size: target_cells,
                             });
-                            if *target_bits < 64 {
+                            if *target_bits % HOST_LIMB_BITS != 0 {
                                 emitter.push_op(bytecode::OpCode::TruncateInt {
                                     res: result,
                                     a: result,
@@ -923,15 +929,19 @@ impl CodeGen {
                             }
                         }
                         (TypeExpr::Int(source_bits), TypeExpr::Int(128)) if *source_bits <= 64 => {
+                            let source_cells = int_cell_count(*source_bits);
+                            let target_cells = int_cell_count(128);
                             emitter.push_op(bytecode::OpCode::MovFrame {
                                 target: result,
                                 source: layouter.get_value(*v),
-                                size: 1,
+                                size: source_cells,
                             });
-                            emitter.push_op(bytecode::OpCode::MovConst {
-                                res: result.offset(1),
-                                val: 0,
-                            });
+                            for cell in source_cells..target_cells {
+                                emitter.push_op(bytecode::OpCode::MovConst {
+                                    res: result.offset(cell as isize),
+                                    val: 0,
+                                });
+                            }
                         }
                         (TypeExpr::Field, TypeExpr::Int(bits)) if *bits <= 64 => {
                             emitter.push_op(bytecode::OpCode::CastFieldToInt {

--- a/compiler/src/compiler/passes/instruction_lowering/bit_range.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/bit_range.rs
@@ -1,6 +1,8 @@
 //! Lowers canonical `BitRange` operations after the witness integer/bitwise passes have emitted
 //! all bit selections.
 
+use mavros_int_semantics::int_bits::FIELD_LIMB_BITS;
+
 use crate::compiler::{
     analysis::types::FunctionTypeInfo,
     ssa::{
@@ -202,14 +204,19 @@ fn decompose_canonical_field_bytes(
     // byte-decomposition below. Read from the configured field (not hardcoded), so no concrete
     // prime is named here; `modulus_lo_m1` is the low half minus one.
     let modulus_limbs = b.field().modulus_limbs();
-    let modulus_hi_u128 = (u128::from(modulus_limbs[3]) << 64) | u128::from(modulus_limbs[2]);
-    let modulus_lo_u128 = (u128::from(modulus_limbs[1]) << 64) | u128::from(modulus_limbs[0]);
+    let modulus_hi_u128 =
+        (u128::from(modulus_limbs[3]) << FIELD_LIMB_BITS) | u128::from(modulus_limbs[2]);
+    let modulus_lo_u128 =
+        (u128::from(modulus_limbs[1]) << FIELD_LIMB_BITS) | u128::from(modulus_limbs[0]);
+
     // `p` is odd, so subtracting one never borrows out of the lowest limb.
     let modulus_lo_m1_u128 = modulus_lo_u128 - 1;
     let modulus_hi = b.field_const(b.field().constant(modulus_hi_u128));
     let modulus_lo_m1 = b.field_const(b.field().constant(modulus_lo_m1_u128));
     let two_to_8 = b.field_const(b.field().constant(256u128));
-    let two_to_64 = b.field_const(b.field().two_pow(64));
+    // One field limb's place value, and one `u128` half's. The `128`s here and below are the
+    // width of the halves the modulus is read in above, not a field limb.
+    let limb_place_value = b.field_const(b.field().two_pow(FIELD_LIMB_BITS));
     let two_to_128 = b.field_const(b.field().two_pow(128));
     let zero = b.field_const(b.field().zero());
 
@@ -243,20 +250,23 @@ fn decompose_canonical_field_bytes(
     let shifted_limb = b.umul(limbs[3], two_to_8);
     limbs[3] = b.uadd(shifted_limb, lsb);
 
-    let hi_upper = b.umul(limbs[0], two_to_64);
+    let hi_upper = b.umul(limbs[0], limb_place_value);
     let hi = b.uadd(hi_upper, limbs[1]);
-    let lo_upper = b.umul(limbs[2], two_to_64);
+    let lo_upper = b.umul(limbs[2], limb_place_value);
     let lo = b.uadd(lo_upper, limbs[3]);
 
     let limb2_pure = b.value_of(limbs[2]);
     let limb3_pure = b.value_of(limbs[3]);
-    let limb2_u64 = b.cast_to(CastTarget::Int(64), limb2_pure);
-    let limb3_u64 = b.cast_to(CastTarget::Int(64), limb3_pure);
+    let limb2_u64 = b.cast_to(CastTarget::Int(FIELD_LIMB_BITS), limb2_pure);
+    let limb3_u64 = b.cast_to(CastTarget::Int(FIELD_LIMB_BITS), limb3_pure);
 
     // The two 64-bit limbs of the low half of `p - 1`, in the same big-endian limb order the byte
     // decomposition above produces; derived from the configured field rather than written out.
-    let mod_limb2 = b.int_const(64, u128::from((modulus_lo_m1_u128 >> 64) as u64));
-    let mod_limb3 = b.int_const(64, u128::from(modulus_lo_m1_u128 as u64));
+    let mod_limb2 = b.int_const(
+        FIELD_LIMB_BITS,
+        u128::from((modulus_lo_m1_u128 >> FIELD_LIMB_BITS) as u64),
+    );
+    let mod_limb3 = b.int_const(FIELD_LIMB_BITS, u128::from(modulus_lo_m1_u128 as u64));
     let hi_lt = b.ult(mod_limb2, limb2_u64);
     let hi_eq = b.eq(mod_limb2, limb2_u64);
     let lo_lt = b.ult(mod_limb3, limb3_u64);

--- a/compiler/src/compiler/passes/instruction_lowering/witness_bitwise.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/witness_bitwise.rs
@@ -2,8 +2,9 @@
 //! explicit-witness pass.
 //!
 //! This pass emits `Spread`/`Unspread` operations, except for `u64` bitwise ops where it keeps a
-//! two-limb `u32` decomposition. It also canonicalizes witness integer casts/shifts into the shared
-//! `BitRange` representation where possible.
+//! two-limb decomposition at half the field's witness limb width (`shared::limbs`) — 32 bits on
+//! bn254. It also canonicalizes witness integer casts/shifts into the shared `BitRange`
+//! representation where possible.
 
 use crate::compiler::{
     analysis::{
@@ -15,7 +16,14 @@ use crate::compiler::{
             InstructionLoweringRule, LoweringContext, integer_bits,
             witness_integer_arith::guarded_or_zero_field,
         },
-        shared::shift_guard::shift_amount_pinned_to,
+        shared::{
+            limbs::{
+                WitnessLimbs, combine_limbs, derive_low_limb, extract_limb, split_into_limbs,
+                spread_sum_fits_field, witness_half_limb_bits, witness_limb_bits,
+            },
+            shift_guard::shift_amount_pinned_to,
+            unsupported::unsupported_on_this_field,
+        },
     },
     ssa::{
         ValueId,
@@ -166,23 +174,34 @@ impl LowerWitnessBitwiseOps {
             return;
         }
 
+        // The `64` and `128` below are the operand's **type** width, not the field's: they pick
+        // which lowering the value needs, and on a narrower field the very same `u64` would need
+        // more limbs rather than fewer.
         let result_word = if bits == 64 {
-            let lhs_limbs = decompose_u64_input(b, lhs, lhs_witness);
-            let rhs_limbs = decompose_u64_input(b, rhs, rhs_witness);
-            let result_limbs = lower_u64_limb_bitwise(b, kind, lhs_limbs, rhs_limbs);
-            combine_u32_limbs(b, result_limbs)
+            let lhs_limbs = decompose_into_half_limbs(b, lhs, bits, lhs_witness);
+            let rhs_limbs = decompose_into_half_limbs(b, rhs, bits, rhs_witness);
+            let result_limbs = lower_limb_bitwise(b, kind, &lhs_limbs, &rhs_limbs);
+            combine_limbs(b, &result_limbs)
         } else if bits == 128 {
-            let lhs_limbs = extract_u128_limbs(b, lhs);
-            let rhs_limbs = extract_u128_limbs(b, rhs);
-            let lhs_lo = decompose_u64_input(b, lhs_limbs.lo, lhs_witness);
-            let rhs_lo = decompose_u64_input(b, rhs_limbs.lo, rhs_witness);
-            let lo = lower_u64_limb_bitwise(b, kind, lhs_lo, rhs_lo);
-            let lhs_hi = decompose_u64_input(b, lhs_limbs.hi, lhs_witness);
-            let rhs_hi = decompose_u64_input(b, rhs_limbs.hi, rhs_witness);
-            let hi = lower_u64_limb_bitwise(b, kind, lhs_hi, rhs_hi);
-            let lo = combine_u32_limbs(b, lo);
-            let hi = combine_u32_limbs(b, hi);
-            combine_u64_fields(b, lo, hi)
+            let limb_bits = witness_limb_bits(b.field());
+            let limb_count = bits.div_ceil(limb_bits);
+            let (lhs_lo_limb, lhs_hi_limb) = split_into_limbs(b, lhs, limb_bits, limb_count).pair();
+            let (rhs_lo_limb, rhs_hi_limb) = split_into_limbs(b, rhs, limb_bits, limb_count).pair();
+            let lhs_lo = decompose_into_half_limbs(b, lhs_lo_limb, limb_bits, lhs_witness);
+            let rhs_lo = decompose_into_half_limbs(b, rhs_lo_limb, limb_bits, rhs_witness);
+            let lo = lower_limb_bitwise(b, kind, &lhs_lo, &rhs_lo);
+            let lhs_hi = decompose_into_half_limbs(b, lhs_hi_limb, limb_bits, lhs_witness);
+            let rhs_hi = decompose_into_half_limbs(b, rhs_hi_limb, limb_bits, rhs_witness);
+            let hi = lower_limb_bitwise(b, kind, &lhs_hi, &rhs_hi);
+            let lo = combine_limbs(b, &lo);
+            let hi = combine_limbs(b, &hi);
+            combine_limbs(
+                b,
+                &WitnessLimbs {
+                    limb_bits,
+                    limbs: vec![lo, hi],
+                },
+            )
         } else {
             lower_word_bitwise(b, kind, lhs, rhs, bits as u8)
         };
@@ -277,11 +296,14 @@ impl LowerWitnessBitwiseOps {
         // `two_pow(to_bits) - two_pow(from_bits)`, which is only the value it is meant to be while
         // `two_pow(to_bits)` has not wrapped. On bn254 the 128-bit cap leaves ample room; on a
         // narrower field this refuses rather than silently extending by a wrapped constant.
-        assert!(
-            to_bits < b.field().field_bit_size() as usize,
-            "sign extension to {to_bits} bits needs a field wider than {} bits",
-            b.field().field_bit_size()
-        );
+        if to_bits >= b.field().field_bit_size() as usize {
+            unsupported_on_this_field(
+                format_args!(
+                    "sign extension from {from_bits} to {to_bits} bits builds its extension term out of `two_pow({to_bits})`, which has itself wrapped, so the widened value would be a residue rather than the sign-extended one"
+                ),
+                b.field(),
+            );
+        }
 
         // The question is whether bit `from_bits - 1` of the encoding is provably clear, so it is
         // asked of the range record rather than of one chosen reading — `SExt`'s source may be
@@ -972,6 +994,12 @@ fn wrap_shifted_product(
     let discarded_bits = discarded_width(&context.urange(rhs), bits);
     product_headroom_or_bail(bits, discarded_bits, b.field());
 
+    // This fallback is deliberately **not** an `unsupported_on_this_field` site, though the defect
+    // the doc above describes is real. Its condition is the integer _type_ cap, which no field
+    // change moves, and its effect is a trapping rangecheck: a shift that should have wrapped is
+    // rejected by the circuit at proving time rather than answered wrongly. Routing it through the
+    // funnel would trade a per-witness rejection for a compile-time refusal of every 128-bit
+    // witness `<<`, including the overwhelming majority that never overflow.
     let wide_bits = 2 * bits;
     if wide_bits > MAX_SUPPORTED_UNSIGNED_BITS {
         guarded_rangecheck(b, product, bits, guard);
@@ -1038,9 +1066,12 @@ fn wrap_shifted_product(
 /// about the lowering.
 fn product_headroom_or_bail(bits: usize, discarded_bits: usize, field: FieldConfig) {
     if !product_fits_field(bits, discarded_bits, field) {
-        unimplemented!(
-            "a witness `<<` at {bits} bits by up to {discarded_bits} needs a limb-wise lowering: the single field product `lhs * 2^n` reaches 2^{} and so wraps modulo the field, which no rangecheck on it can detect. See docs/field-agnosticism.md, L6-int-op-strategy.",
-            bits + discarded_bits
+        unsupported_on_this_field(
+            format_args!(
+                "a witness `<<` at {bits} bits by up to {discarded_bits} needs a limb-wise lowering: the single field product `lhs * 2^n` reaches 2^{} and so wraps modulo the field, which no rangecheck on it can detect",
+                bits + discarded_bits
+            ),
+            field,
         );
     }
 }
@@ -1086,18 +1117,6 @@ fn discarded_width(amount: &Interval, bits: usize) -> usize {
         Some(hi) => hi.to_usize().unwrap_or(cap).min(cap),
         None => cap,
     }
-}
-
-#[derive(Clone, Copy)]
-struct U64Limbs {
-    lo: ValueId,
-    hi: ValueId,
-}
-
-#[derive(Clone, Copy)]
-struct U128Limbs {
-    lo: ValueId,
-    hi: ValueId,
 }
 
 fn guarded_rangecheck(
@@ -1146,10 +1165,16 @@ fn spread_as_field(b: &mut impl HLEmitter, value: ValueId, bits: u8) -> ValueId 
     b.cast_to_field(spread)
 }
 
+/// Bitwise on a whole `bits`-wide word, via spread-then-add.
+///
+/// The two callers reach here by different routes and only one of them has already been sized by
+/// the field: `lower_limb_bitwise` arrives at [`witness_half_limb_bits`], while the sub-64 arm of
+/// [`LowerWitnessBitwiseOps::lower_binary_bitwise`] arrives at the operand's own **type** width.
 // FIELD-ASSUMPTION: L6-int-op-strategy
 // Bitwise via spread-then-add: the spread of a `bits`-wide value occupies ~2*bits bits (cast
-// to `U(bits*2)`), so on a ~64-bit field even a 32-bit spread nearly saturates p. Small fields
-// need narrower spread limbs (why u64/u128 are already split into 32-bit limbs).
+// to `U(bits*2)`), so on a ~64-bit field even a 32-bit spread nearly saturates p. A half-limb
+// operand satisfies `2*bits <= h` by construction, which is why u64/u128 go through a half-limb
+// decomposition; a narrower type width arriving directly does not, and is what the refusal is for.
 fn lower_word_bitwise(
     b: &mut impl HLEmitter,
     kind: BinaryArithOpKind,
@@ -1157,6 +1182,16 @@ fn lower_word_bitwise(
     rhs: ValueId,
     bits: u8,
 ) -> ValueId {
+    if !spread_sum_fits_field(bits as usize, b.field()) {
+        unsupported_on_this_field(
+            format_args!(
+                "a {bits}-bit bitwise op spreads each operand to {} bits, and the sum of the two spreads no longer fits one field element, so `Unspread` would read a residue rather than the interleaved bits",
+                2 * bits as usize
+            ),
+            b.field(),
+        );
+    }
+
     let lhs_spread = spread_as_field(b, lhs, bits);
     let rhs_spread = spread_as_field(b, rhs, bits);
     let input_spread_sum = b.uadd(lhs_spread, rhs_spread);
@@ -1171,91 +1206,160 @@ fn lower_word_bitwise(
     }
 }
 
-fn lower_u64_limb_bitwise(
+/// Bitwise limb by limb, at the width the operands were decomposed to.
+///
+/// Bitwise that needs no carries between limbs, so this is a plain zip: the width comes off the
+/// operands rather than from a second query of the field, because they were split by
+/// [`decompose_into_half_limbs`].
+fn lower_limb_bitwise(
     b: &mut impl HLEmitter,
     kind: BinaryArithOpKind,
-    lhs: U64Limbs,
-    rhs: U64Limbs,
-) -> U64Limbs {
-    U64Limbs {
-        lo: lower_word_bitwise(b, kind, lhs.lo, rhs.lo, 32),
-        hi: lower_word_bitwise(b, kind, lhs.hi, rhs.hi, 32),
-    }
+    lhs: &WitnessLimbs,
+    rhs: &WitnessLimbs,
+) -> WitnessLimbs {
+    assert_eq!(
+        lhs.limb_bits, rhs.limb_bits,
+        "bitwise operands were decomposed at different limb widths"
+    );
+    assert_eq!(
+        lhs.limbs.len(),
+        rhs.limbs.len(),
+        "bitwise operands were decomposed into different limb counts"
+    );
+    let limb_bits = lhs.limb_bits;
+    let limbs = lhs
+        .limbs
+        .iter()
+        .zip(&rhs.limbs)
+        .map(|(&lhs_limb, &rhs_limb)| {
+            lower_word_bitwise(b, kind, lhs_limb, rhs_limb, limb_bits as u8)
+        })
+        .collect();
+    WitnessLimbs { limb_bits, limbs }
 }
 
-// FIELD-ASSUMPTION: L6-int-representation (combine_u32_limbs + combine_u64_fields)
-// These recombine limbs into a single field cell (`lo + hi * 2^32` / `lo + hi * 2^64`). The
-// 2^64 recombination exceeds p on a ~64-bit field, so wide results cannot live in one cell and
-// must stay multi-cell; the shift width must derive from the field size.
-fn combine_u32_limbs(b: &mut impl HLEmitter, limbs: U64Limbs) -> ValueId {
-    let lo = b.cast_to_field(limbs.lo);
-    let hi = b.cast_to_field(limbs.hi);
-    let shift = b.field_const(b.field().constant(1u128 << 32));
-    let shifted_hi = b.umul(hi, shift);
-    b.uadd(lo, shifted_hi)
-}
-
-fn combine_u64_fields(b: &mut impl HLEmitter, lo: ValueId, hi: ValueId) -> ValueId {
-    let lo = b.cast_to_field(lo);
-    let hi = b.cast_to_field(hi);
-    // FIELD-ASSUMPTION: L4-decompose
-    let shift = b.field_const(b.field().two_pow(64));
-    let shifted_hi = b.umul(hi, shift);
-    b.uadd(lo, shifted_hi)
-}
-
-fn extract_u128_limbs(b: &mut impl HLEmitter, value: ValueId) -> U128Limbs {
-    U128Limbs {
-        lo: extract_u128_limb(b, value, 0),
-        hi: extract_u128_limb(b, value, 64),
-    }
-}
-
-fn extract_u128_limb(b: &mut impl HLEmitter, value: ValueId, offset: usize) -> ValueId {
-    let limb = b.bit_range(value, offset, 64);
-    b.cast_to(CastTarget::Int(64), limb)
-}
-
-fn decompose_u64_input(b: &mut impl HLEmitter, value: ValueId, is_witness: bool) -> U64Limbs {
+/// Split one witness limb into its two half-limbs, hinting the high half when the value is a
+/// witness.
+///
+/// The pure arm is an ordinary bit-range split. The witness arm cannot be as a witnessed value has
+/// no bits to range over, so the high half is hinted from the pure shadow, written as a witness,
+/// and the low half recovered by subtraction to yield one witness and one implicit range check
+/// instead of two of each.
+fn decompose_into_half_limbs(
+    b: &mut impl HLEmitter,
+    value: ValueId,
+    value_bits: usize,
+    is_witness: bool,
+) -> WitnessLimbs {
+    let half_bits = witness_half_limb_bits(b.field());
+    assert_eq!(
+        value_bits,
+        2 * half_bits,
+        "a half-limb decomposition covers exactly one witness limb"
+    );
     if !is_witness {
-        return extract_u64_limbs(b, value);
+        return split_into_limbs(b, value, half_bits, 2);
     }
 
     let pure_value = b.value_of(value);
-    let hi_hint = extract_u64_limb(b, pure_value, 32);
+    let hi_hint = extract_limb(b, pure_value, half_bits, half_bits);
     let hi_field = b.cast_to_field(hi_hint);
     let hi_wit = b.write_witness(hi_field);
-    let lo = derive_low_u32_limb(b, value, hi_wit);
+    let lo = derive_low_limb(b, value, hi_wit, half_bits);
 
-    U64Limbs {
-        lo,
-        hi: b.cast_to(CastTarget::Int(32), hi_wit),
+    WitnessLimbs {
+        limb_bits: half_bits,
+        limbs: vec![lo, b.cast_to(CastTarget::Int(half_bits), hi_wit)],
     }
-}
-
-fn extract_u64_limbs(b: &mut impl HLEmitter, value: ValueId) -> U64Limbs {
-    U64Limbs {
-        lo: extract_u64_limb(b, value, 0),
-        hi: extract_u64_limb(b, value, 32),
-    }
-}
-
-fn extract_u64_limb(b: &mut impl HLEmitter, value: ValueId, offset: usize) -> ValueId {
-    let limb = b.bit_range(value, offset, 32);
-    b.cast_to(CastTarget::Int(32), limb)
-}
-
-fn derive_low_u32_limb(b: &mut impl HLEmitter, value: ValueId, hi_field: ValueId) -> ValueId {
-    let value_field = b.cast_to_field(value);
-    let shift = b.field_const(b.field().constant(1u128 << 32));
-    let shifted_hi = b.umul(hi_field, shift);
-    let lo_field = b.usub(value_field, shifted_hi);
-    b.cast_to(CastTarget::Int(32), lo_field)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::compiler::ssa::hlssa::{HLSSA, builder::HLSSABuilder};
+
+    /// The two routes into [`lower_word_bitwise`], both cleared on bn254.
+    ///
+    /// [`spread_sum_fits_field`]'s own boundary is pinned in `shared::limbs`; what belongs here is
+    /// the local claim that no width this dispatch can deliver reaches it.
+    #[test]
+    fn no_width_this_lowering_spreads_at_can_wrap_bn254() {
+        let bn254 = FieldConfig::bn254();
+
+        // The half-limb route, and the widths the sub-64 arm reaches directly.
+        assert!(spread_sum_fits_field(witness_half_limb_bits(bn254), bn254));
+        for bits in [2usize, 8, 16, 32, 63] {
+            assert!(spread_sum_fits_field(bits, bn254), "{bits} bits");
+        }
+
+        // And the refusal is unreachable by a second, independent margin: the `U(bits * 2)` cast is
+        // capped at `MAX_SUPPORTED_UNSIGNED_BITS`, so no width past 64 could have been spread here
+        // at all, while the predicate itself only bites at 128.
+        assert!(2 * 65 > MAX_SUPPORTED_UNSIGNED_BITS);
+        assert!(spread_sum_fits_field(127, bn254));
+    }
+
+    /// `lower_limb_bitwise` lowers *every* limb, not the first two.
+    ///
+    /// Both callers hand it a two-limb decomposition today, so the zip past the pair — and the
+    /// length check that stops `zip` from silently truncating a mismatched one — has no other
+    /// coverage. Phase 4's `⌈n/h⌉` dispatch is what will reach it in production.
+    #[test]
+    fn a_bitwise_decomposition_is_lowered_limb_by_limb_at_any_length() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            sb.modify_function(main_id, |b| {
+                let entry = b.function.get_entry_id();
+                let mut e = b.test_block(entry);
+                let lhs = e.int_const(24, 0x00_AB_CD);
+                let rhs = e.int_const(24, 0x00_12_34);
+                let lhs_limbs = split_into_limbs(&mut e, lhs, 8, 3);
+                let rhs_limbs = split_into_limbs(&mut e, rhs, 8, 3);
+                let result =
+                    lower_limb_bitwise(&mut e, BinaryArithOpKind::And, &lhs_limbs, &rhs_limbs);
+                assert_eq!(result.limb_bits, 8);
+                assert_eq!(result.limbs.len(), 3, "one result limb per operand limb");
+                e.terminate_return(vec![]);
+            });
+        }
+
+        // One spread per operand limb and one unspread per result limb: six and three, not the four
+        // and two a pair-shaped lowering would have emitted.
+        let function = ssa.get_unique_entrypoint();
+        let ops: Vec<&OpCode> = function
+            .get_block(function.get_entry_id())
+            .get_instructions()
+            .collect();
+        let spreads = ops
+            .iter()
+            .filter(|op| matches!(op, OpCode::Spread { bits: 8, .. }))
+            .count();
+        let unspreads = ops
+            .iter()
+            .filter(|op| matches!(op, OpCode::Unspread { bits: 8, .. }))
+            .count();
+        assert_eq!((spreads, unspreads), (6, 3));
+    }
+
+    #[test]
+    #[should_panic(expected = "decomposed into different limb counts")]
+    fn a_bitwise_pair_of_unequal_length_is_refused_rather_than_truncated() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let mut sb = HLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |b| {
+            let entry = b.function.get_entry_id();
+            let mut e = b.test_block(entry);
+            let lhs = e.int_const(24, 0);
+            let rhs = e.int_const(16, 0);
+            let lhs_limbs = split_into_limbs(&mut e, lhs, 8, 3);
+            let rhs_limbs = split_into_limbs(&mut e, rhs, 8, 2);
+            lower_limb_bitwise(&mut e, BinaryArithOpKind::And, &lhs_limbs, &rhs_limbs);
+        });
+    }
 
     #[test]
     fn a_wide_shift_is_refused_exactly_when_its_product_can_wrap_the_field() {

--- a/compiler/src/compiler/passes/instruction_lowering/witness_field.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/witness_field.rs
@@ -1,5 +1,8 @@
 use crate::compiler::{
-    passes::instruction_lowering::{InstructionLoweringRule, LoweringContext},
+    passes::{
+        instruction_lowering::{InstructionLoweringRule, LoweringContext},
+        shared::unsupported::unsupported_on_this_field,
+    },
     ssa::{
         ValueId,
         hlssa::{
@@ -273,13 +276,17 @@ impl LowerWitnessFieldOps {
         if !context.types().get_value_type(value).is_witness_of() {
             return false;
         }
-        // This limit is tied to the active field. Supporting wider decompositions will require
-        // deciding how their leading zeroes participate in the field-agnostic lowering contract.
-        assert!(
-            count <= b.field().field_bit_size() as usize,
-            "witness ToBits width {count} exceeds field bit size {}",
-            b.field().field_bit_size()
-        );
+        // Supporting wider decompositions will require deciding how their leading zeroes
+        // participate in the field-agnostic lowering contract, which is why this refuses rather
+        // than padding.
+        if count > b.field().field_bit_size() as usize {
+            unsupported_on_this_field(
+                format_args!(
+                    "a witness `to_bits` of {count} bits asks for more bits than a field element has"
+                ),
+                b.field(),
+            );
+        }
 
         // Compute the decomposition in witgen, then bind each hinted bit to a fresh circuit
         // witness. WitnessWriteToFresh removes this hint chain from the R1CS pipeline later.
@@ -384,13 +391,17 @@ impl LowerWitnessFieldOps {
             return true;
         }
 
-        // Unlike bits, the top byte may be only partially occupied (BN254 therefore needs 32
-        // bytes). Wider zero-padded decompositions need an explicit field-agnostic contract.
+        // Unlike bits, the top byte may be only partially occupied (BN254 needs 32 bytes). Wider
+        // zero-padded decompositions need an explicit field-agnostic contract.
         let max_bytes = (b.field().field_bit_size() as usize).div_ceil(8);
-        assert!(
-            count <= max_bytes,
-            "witness ToRadix byte count {count} exceeds field byte width {max_bytes}"
-        );
+        if count > max_bytes {
+            unsupported_on_this_field(
+                format_args!(
+                    "a witness `to_radix` of {count} bytes asks for more than the {max_bytes} bytes a field element occupies"
+                ),
+                b.field(),
+            );
+        }
 
         let pure_value = b.value_of(value);
         let hint = b.to_radix(pure_value, radix, endianness, count);

--- a/compiler/src/compiler/passes/instruction_lowering/witness_integer_arith.rs
+++ b/compiler/src/compiler/passes/instruction_lowering/witness_integer_arith.rs
@@ -5,7 +5,15 @@ use mavros_artifacts::FieldConfig;
 
 use crate::compiler::{
     analysis::value_range_analysis::{Interval, field_modulus},
-    passes::instruction_lowering::{InstructionLoweringRule, LoweringContext, integer_bits},
+    passes::{
+        instruction_lowering::{InstructionLoweringRule, LoweringContext, integer_bits},
+        shared::{
+            limbs::{
+                WitnessLimbs, split_into_limbs, two_limb_product_packing_fits, witness_limb_bits,
+            },
+            unsupported::unsupported_on_this_field,
+        },
+    },
     ssa::{
         ValueId,
         hlssa::{
@@ -168,11 +176,13 @@ impl LowerWitnessIntegerArithOps {
     }
 
     // FIELD-ASSUMPTION: L6-int-op-strategy
-    // The full product is computed in one field element (guarded by
-    // `range_fits_field_injectively`). The only non-single-field path is the u128 fallback
-    // below, and it still packs `lo + cross*2^64` (~2^193) into one cell — so it assumes ~193
-    // bits of headroom. On a small field u32/u64 mul need a schoolbook multi-limb lowering
-    // with per-limb range checks and carries (see docs/field-agnosticism.md, Layer 6).
+    // The full product is computed in one field element (by `range_fits_field_injectively`). The
+    // only non-single-field path is the u128 fallback below, and it still packs
+    // `lo + cross*2^h` — roughly `2^(3h+1)`, so ~2^193 at the bn254 limb — into one cell. That is a
+    // strictly stronger demand than the limb width itself certifies, which is why the fallback asks
+    // `two_limb_product_packing_fits` rather than inferring it from `h`. On a small field u32/u64
+    // mul need a schoolbook multi-limb lowering with per-limb range checks and carries
+    // (see docs/field-agnosticism.md, Layer 6).
     fn lower_unsigned_mul(
         &self,
         b: &mut HLBlockEmitter<'_>,
@@ -185,12 +195,25 @@ impl LowerWitnessIntegerArithOps {
     ) {
         let product_range = context.urange(lhs).mul(&context.urange(rhs));
         if bits == 128 && !range_fits_field_injectively(&product_range, b.field()) {
-            let lhs_limbs = split_u128_value(b, lhs);
-            let rhs_limbs = split_u128_value(b, rhs);
-            let lhs_lo = b.cast_to_field(lhs_limbs.lo);
-            let lhs_hi = b.cast_to_field(lhs_limbs.hi);
-            let rhs_lo = b.cast_to_field(rhs_limbs.lo);
-            let rhs_hi = b.cast_to_field(rhs_limbs.hi);
+            // The limb width says a single `a·b` fits; this packing scales a two-product column by
+            // `2^h` on top of that, and no rangecheck on the packed value can tell an honest one
+            // from a wrapped residue. The same question covers the limb _count_, because the code
+            // below reads each split as a pair.
+            if !two_limb_product_packing_fits(b.field(), bits) {
+                unsupported_on_this_field(
+                    format_args!(
+                        "a {bits}-bit unsigned multiplication falls back to a two-limb schoolbook product, which needs the operands to be two witness limbs and needs its `lo + cross * 2^h` packing — about 2^(3h+1) — not to wrap modulo the field"
+                    ),
+                    b.field(),
+                );
+            }
+
+            let (lhs_lo_limb, lhs_hi_limb) = split_u128_value(b, lhs).pair();
+            let (rhs_lo_limb, rhs_hi_limb) = split_u128_value(b, rhs).pair();
+            let lhs_lo = b.cast_to_field(lhs_lo_limb);
+            let lhs_hi = b.cast_to_field(lhs_hi_limb);
+            let rhs_lo = b.cast_to_field(rhs_lo_limb);
+            let rhs_hi = b.cast_to_field(rhs_hi_limb);
 
             let lo_product = b.umul(lhs_lo, rhs_lo);
             let lhs_cross = b.umul(lhs_lo, rhs_hi);
@@ -203,7 +226,7 @@ impl LowerWitnessIntegerArithOps {
             b.constrain(flag, high_product, zero);
 
             let cross = b.uadd(lhs_cross, rhs_cross);
-            let shift = b.field_const(b.field().two_pow(64));
+            let shift = b.field_const(b.field().two_pow(witness_limb_bits(b.field())));
             let shifted_cross = b.umul(cross, shift);
             let value = b.uadd(lo_product, shifted_cross);
             guarded_rangecheck(b, value, bits, guard);
@@ -216,10 +239,14 @@ impl LowerWitnessIntegerArithOps {
             return;
         }
 
-        assert!(
-            range_fits_field_injectively(&product_range, b.field()),
-            "unsigned multiplication product range is too wide for a single-field product"
-        );
+        if !range_fits_field_injectively(&product_range, b.field()) {
+            unsupported_on_this_field(
+                format_args!(
+                    "a {bits}-bit unsigned multiplication whose product spans {product_range:?} needs a schoolbook multi-limb lowering: that span has representatives a single field product cannot tell apart"
+                ),
+                b.field(),
+            );
+        }
 
         let lhs_field = b.cast_to_field(lhs);
         let rhs_field = b.cast_to_field(rhs);
@@ -281,10 +308,14 @@ impl LowerWitnessIntegerArithOps {
             ArithGroup::Sub => lhs_range.sub(&rhs_range),
             _ => unreachable!(),
         };
-        assert!(
-            range_fits_field_injectively(&result_range, b.field()),
-            "signed add/sub result range is too wide for a single-field encoding"
-        );
+        if !range_fits_field_injectively(&result_range, b.field()) {
+            unsupported_on_this_field(
+                format_args!(
+                    "a {bits}-bit {kind:?} whose result spans {result_range:?} needs a multi-limb lowering: that span has representatives a single-field signed encoding cannot tell apart"
+                ),
+                b.field(),
+            );
+        }
 
         // `lhs_signed`/`rhs_signed` are decoded _field_ values, so this is field arithmetic and
         // takes the unsigned forms even though the operands it came from are signed integers.
@@ -336,10 +367,14 @@ impl LowerWitnessIntegerArithOps {
         let lhs_range = context.srange(lhs);
         let rhs_range = context.srange(rhs);
         let product_range = lhs_range.mul(&rhs_range);
-        assert!(
-            range_fits_field_injectively(&product_range, b.field()),
-            "signed multiplication product range is too wide for a single-field product"
-        );
+        if !range_fits_field_injectively(&product_range, b.field()) {
+            unsupported_on_this_field(
+                format_args!(
+                    "a {bits}-bit signed multiplication whose product spans {product_range:?} needs a schoolbook multi-limb lowering: that span has representatives a single field product cannot tell apart"
+                ),
+                b.field(),
+            );
+        }
 
         let lhs_witness = context.types().get_value_type(lhs).is_witness_of();
         let rhs_witness = context.types().get_value_type(rhs).is_witness_of();
@@ -751,26 +786,19 @@ struct DivModResult {
     r_is_witness: bool,
 }
 
-#[derive(Clone, Copy)]
-struct U128Limbs {
-    lo: ValueId,
-    hi: ValueId,
-}
-
 // FIELD-ASSUMPTION: L6-int-representation
-// A fixed 2x64-bit split of a u128. On a small field the limb width must derive from the
-// field size (h ~= field_bits/2), and wide integers become multi-cell values end-to-end.
-fn split_u128_value(b: &mut impl HLEmitter, value: ValueId) -> U128Limbs {
-    let value = b.cast_to(CastTarget::Int(128), value);
-    U128Limbs {
-        lo: split_u128_limb(b, value, 0),
-        hi: split_u128_limb(b, value, 64),
-    }
-}
-
-fn split_u128_limb(b: &mut impl HLEmitter, value: ValueId, offset: usize) -> ValueId {
-    let limb = b.bit_range(value, offset, 64);
-    b.cast_to(CastTarget::Int(64), limb)
+// The limb width is now the field's, but the _count_ still has to land at two for
+// `lower_unsigned_mul` above, which reads the split as a pair. That caller asks
+// `two_limb_product_packing_fits` — which answers about the count as well as the packing — so a
+// narrower field refuses before reaching here rather than tripping `WitnessLimbs::pair`; making the
+// caller total is Phase 4's multi-cell work, not a wider constant.
+fn split_u128_value(b: &mut impl HLEmitter, value: ValueId) -> WitnessLimbs {
+    // The operand's **type** width, which is what decides how many limbs it takes — the field only
+    // decides how wide each one is.
+    const BITS: usize = 128;
+    let value = b.cast_to(CastTarget::Int(BITS), value);
+    let limb_bits = witness_limb_bits(b.field());
+    split_into_limbs(b, value, limb_bits, BITS.div_ceil(limb_bits))
 }
 
 // FIELD-ASSUMPTION: L6-int-op-strategy

--- a/compiler/src/compiler/passes/shared/limbs.rs
+++ b/compiler/src/compiler/passes/shared/limbs.rs
@@ -1,0 +1,688 @@
+//! The witness limb: how wide a piece of an integer can be for a given field.
+//!
+//! This governs witness layout and the widths the spread-based bitwise lowering works at. It is
+//! also the width the schoolbook multiplier and its carry chain will be built at when P5 lands —
+//! see `docs/field-agnosticism.md`, Layer 6.
+
+use num_bigint::BigInt;
+use num_traits::One;
+
+use mavros_artifacts::FieldConfig;
+use mavros_int_semantics::int_bits::HOST_LIMB_BITS;
+
+use crate::compiler::{
+    analysis::value_range_analysis::field_modulus,
+    passes::shared::unsupported::unsupported_on_this_field,
+    ssa::{
+        ValueId,
+        hlssa::{CastTarget, builder::HLEmitter},
+    },
+};
+
+// THE WITNESS LIMB WIDTH
+// ================================================================================================
+
+/// The width to fall back to when a field is too small to carry any limb at all.
+///
+/// Also the narrowest admissible width, so [`limb_bits_for_modulus`] is total: every field gets an
+/// answer, and the width guards downstream are the ones that refuse.
+const NARROWEST_LIMB_BITS: usize = 1;
+
+/// What a witness limb has to be able to fit: the parameters that determine its width.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LimbBudget {
+    /// How many `h`-bit partial products must fit in one field element at once.
+    ///
+    /// `1` asks only that a bare `a·b` not wrap: a limb is exactly what multiplies in-field, and
+    /// nothing more. Each doubling buys one more product per reduction and costs a narrower limb,
+    /// so the trade is **reductions against limb count**: a bigger budget means more limbs per
+    /// value and more partial products overall, but longer runs between witnessed, range-checked
+    /// carry extractions as part of the reduction.
+    ///
+    /// At `1` a schoolbook `acc += a·b` does not fit whenever this is the binding constraint, so
+    /// such a field's accumulator has to reduce after every product rather than per column.
+    ///
+    /// This counts **products**, not place-value headroom. A lowering that scales a column by `2^h`
+    /// before adding it, spreads its operands, or recombines its limbs needs a strictly stronger
+    /// condition than any setting here states. Those conditions are the separate predicates listed
+    /// on [`witness_limb_bits`].
+    pub accumulated_products: u32,
+}
+
+impl LimbBudget {
+    /// The budget the compiler actually runs on.
+    ///
+    /// `accumulated_products: 1` buys the **widest** limb the field allows, which is the trade the
+    /// corpus suggests: its lookup traffic is 8-, 16- and 32-bit, not long chains of multiply and
+    /// accumulate.
+    pub const DEFAULT: LimbBudget = LimbBudget {
+        accumulated_products: 1,
+    };
+}
+
+/// The admissible limb widths, widest first: the powers of two up to [`HOST_LIMB_BITS`].
+///
+/// Never empty — [`NARROWEST_LIMB_BITS`] is always the last entry.
+///
+/// The ceiling is [`HOST_LIMB_BITS`] and is deliberately **not** a budget knob: a limb is carried
+/// in a host word and an `IntBits` limb, so it is pinned by the representation, not chosen. Making
+/// it settable would let a caller ask for a limb that has nowhere to live.
+fn candidate_widths() -> Vec<usize> {
+    (NARROWEST_LIMB_BITS..=HOST_LIMB_BITS)
+        .rev()
+        .filter(|w| w.is_power_of_two())
+        .collect()
+}
+
+/// The witness limb width `h` for `field`.
+///
+/// `h` is the width a value is chopped into before its pieces are packed into field elements. It
+/// governs the splits in `witness_bitwise` and `witness_integer_arith`.
+///
+/// See [`limb_bits_for_modulus`] for the rule and [`LimbBudget`] for the tuning tools. Each of
+/// these is a separate predicate because each asks for strictly more than one bare `a·b`:
+///
+/// - that a lowering which scales a limb column by a place value still fits
+///   ([`two_limb_product_packing_fits`]);
+/// - that the sum of two spreads still fits ([`spread_sum_fits_field`]);
+/// - that the limbs recombine into one cell ([`combined_limbs_fit_field`]).
+pub fn witness_limb_bits(field: FieldConfig) -> usize {
+    limb_bits_for_modulus(&field_modulus(field), LimbBudget::DEFAULT)
+}
+
+/// The widest admissible limb whose partial products still fit `modulus`, under `budget`.
+///
+/// The predicate is stated against the **modulus itself**, not its bit length, necessary to take
+/// full advantage of potential limb sizes. Goldilocks, for example, is `2^64 - 2^32 + 1`, so
+/// `(2^32 - 1)^2` clears it by exactly `2^32` and a bit-count bound of the form `2h < field_bits`
+/// would reject a 32-bit limb that fits.
+pub fn limb_bits_for_modulus(modulus: &BigInt, budget: LimbBudget) -> usize {
+    candidate_widths()
+        .into_iter()
+        .find(|&limb_bits| {
+            let max_limb = (BigInt::one() << limb_bits) - BigInt::one();
+            let budgeted = (&max_limb * &max_limb) * BigInt::from(budget.accumulated_products);
+            budgeted < *modulus
+        })
+        // A field too small for even the narrowest limb is not one this compiler can lower for at
+        // all; returning the narrowest lets the width guards downstream be the ones that refuse.
+        .unwrap_or(NARROWEST_LIMB_BITS)
+}
+
+/// Half a witness limb: the width the spread-based bitwise lowering operates at.
+///
+/// `Spread` interleaves zero bits, so the spread of a `k`-bit value occupies `2k` bits. Taking
+/// `k = h/2` is what makes a spread occupy exactly one limb, which is why 64-bit bitwise splits
+/// into 32-bit pieces on bn254 rather than spreading the word whole.
+///
+/// # Panics
+///
+/// If the limb has no exact half. The halves have to cover the limb between them: `derive_low_limb`
+/// range-checks the low half to exactly this many bits, so an odd `h` would leave the top bit of
+/// the low half unconstrained. [`LimbBudget`] admits only powers of two precisely so this holds,
+/// and the assertion pins that the two have not drifted apart.
+pub fn witness_half_limb_bits(field: FieldConfig) -> usize {
+    let limb_bits = witness_limb_bits(field);
+    assert!(
+        limb_bits >= 2 && limb_bits.is_power_of_two(),
+        "a {limb_bits}-bit limb has no exact half, so two half-limbs would not cover it"
+    );
+    limb_bits / 2
+}
+
+/// Whether a `bits`-wide value's two-limb schoolbook product recombines into one field element.
+///
+/// Two things have to hold:
+///
+/// - `bits` has to (for now) decompose into exactly two limbs on this field, because the lowering
+///   reads the split as a pair. On a narrower field the same width yields more limbs and there is
+///   no two-limb product to pack.
+/// - The packed column has to fit. [`witness_limb_bits`] certifies that **one** partial product
+///   fits, which is all [`LimbBudget::accumulated_products`] can express. A schoolbook
+///   `lo·lo + (lo·hi + hi·lo)·2^h` asks for more, because the place value scales a two-product
+///   column. See [`two_limb_packing_fits_modulus`] for that half.
+pub fn two_limb_product_packing_fits(field: FieldConfig, bits: usize) -> bool {
+    let limb_bits = witness_limb_bits(field);
+    bits.div_ceil(limb_bits) == 2 && two_limb_packing_fits_modulus(&field_modulus(field), limb_bits)
+}
+
+/// Whether `lo·lo + (lo·hi + hi·lo)·2^h` stays below `modulus` for limbs of `limb_bits` bits.
+///
+/// With limbs bounded by `M = 2^h − 1` the packed value reaches `M²·(2^{h+1} + 1)`, roughly
+/// `2^{3h+1}`. On bn254 that is ~2^193 against a ~2^254 modulus, but it does not follow from the
+/// limb width: a field wide enough for `M²` — which is all the budget asks — can still be far too
+/// narrow for `M²·2^{h+1}`.
+pub fn two_limb_packing_fits_modulus(modulus: &BigInt, limb_bits: usize) -> bool {
+    let max_limb = (BigInt::one() << limb_bits) - BigInt::one();
+    let packed = &max_limb * &max_limb * ((BigInt::one() << (limb_bits + 1)) + BigInt::one());
+    packed < *modulus
+}
+
+/// Whether the sum of two `bits`-wide spreads still fits one element of `field`.
+///
+/// The spread-then-add bitwise lowering adds two spreads and hands the sum to `Unspread`, which
+/// reads the interleaved bits back out. Once the sum can wrap, `Unspread` reads a residue instead.
+pub fn spread_sum_fits_field(bits: usize, field: FieldConfig) -> bool {
+    spread_sum_fits_modulus(bits, &field_modulus(field))
+}
+
+/// Whether the sum of two `bits`-wide spreads stays below `modulus`.
+///
+/// `Spread` interleaves zero bits, so a `bits`-wide spread occupies the even positions below
+/// `2*bits` and is at most `(4^bits − 1)/3`; two of them sum to at most twice that.
+///
+/// Stated against the modulus rather than its bit length for the same reason
+/// [`limb_bits_for_modulus`] is: the sum is barely over two thirds of `2^(2*bits)`, so a bound of
+/// the form `2*bits < field_bits` gives away a whole width. It is the difference between accepting
+/// and refusing a bare `u32` bitwise op on goldilocks, which `docs/field-agnosticism.md` records
+/// as fitting.
+pub fn spread_sum_fits_modulus(bits: usize, modulus: &BigInt) -> bool {
+    let max_spread = ((BigInt::one() << (2 * bits)) - BigInt::one()) / 3;
+    (max_spread << 1) < *modulus
+}
+
+/// Whether `limb_count` limbs of `limb_bits` bits each recombine into one element of `field`.
+///
+/// This is [`combine_limbs`]' own precondition, and the representation half of the same question
+/// the two predicates above ask about operations: the recombined value reaches
+/// `2^(limb_count · limb_bits) − 1`, and once that can exceed the modulus the sum is a residue and
+/// nothing downstream can tell it from the honest value.
+pub fn combined_limbs_fit_field(field: FieldConfig, limb_bits: usize, limb_count: usize) -> bool {
+    combined_limbs_fit_modulus(&field_modulus(field), limb_bits, limb_count)
+}
+
+/// Whether `limb_count` limbs of `limb_bits` bits each recombine below `modulus`.
+///
+/// The limbs are bounded by their own width, so the recombination is below `2^(limb_count ·
+/// limb_bits)`; that bound is tight, since every limb may be all ones.
+pub fn combined_limbs_fit_modulus(modulus: &BigInt, limb_bits: usize, limb_count: usize) -> bool {
+    (BigInt::one() << (limb_bits * limb_count)) <= *modulus
+}
+
+// LIMB DECOMPOSITIONS
+// ================================================================================================
+
+/// A value decomposed into equal-width limbs, least significant first.
+///
+/// Equal-width is a contract, but does **not** forbid slack in the top limb. A limb carrying fewer
+/// meaningful bits than its width, the rest provably zero, is an ordinary `Int(limb_bits)` like
+/// every other one.
+///
+/// The limbs are usually `Int(limb_bits)` values, but [`combine_limbs`] also accepts already-field
+/// limbs — `witness_bitwise`'s 128-bit path recombines two field-valued halves that way — so a
+/// consumer should not assume the integer typing without checking.
+pub struct WitnessLimbs {
+    /// The width of each limb, in bits.
+    pub limb_bits: usize,
+
+    /// The limbs, least significant first.
+    pub limbs: Vec<ValueId>,
+}
+
+impl WitnessLimbs {
+    /// The two limbs, least significant first, or a panic if there are not exactly two.
+    pub fn pair(&self) -> (ValueId, ValueId) {
+        assert_eq!(
+            self.limbs.len(),
+            2,
+            "this lowering reads a decomposition as a pair, but it has {} limbs of {} bits",
+            self.limbs.len(),
+            self.limb_bits
+        );
+        (self.limbs[0], self.limbs[1])
+    }
+}
+
+/// Split `value` into `count` limbs of `limb_bits` bits each, least significant first.
+///
+/// `count * limb_bits` must not exceed the value's width: a `BitRange` past its source is rejected,
+/// so a value that is not a whole number of limbs has to be widened before it can be split.
+pub fn split_into_limbs(
+    b: &mut impl HLEmitter,
+    value: ValueId,
+    limb_bits: usize,
+    count: usize,
+) -> WitnessLimbs {
+    let mut limbs = Vec::with_capacity(count);
+    for i in 0..count {
+        limbs.push(extract_limb(b, value, i * limb_bits, limb_bits));
+    }
+    WitnessLimbs { limb_bits, limbs }
+}
+
+/// Extract the `limb_bits` bits of `value` starting at `offset` as an integer of that width.
+pub fn extract_limb(
+    b: &mut impl HLEmitter,
+    value: ValueId,
+    offset: usize,
+    limb_bits: usize,
+) -> ValueId {
+    let limb = b.bit_range(value, offset, limb_bits);
+    b.cast_to(CastTarget::Int(limb_bits), limb)
+}
+
+/// Recombine `limbs` into a single field value, `limb[0] + limb[1] * 2^h + ...`.
+///
+/// Refuses on a field the recombination does not fit; see [`combined_limbs_fit_field`].
+// FIELD-ASSUMPTION: L6-int-representation
+// The result is one field element, so this is sound only while the recombined value fits one — it
+// is the _representation_ half of the assumption that survives limb widths becoming field-derived.
+// The widths are now `h` and the fit is now checked rather than assumed, so a narrow field refuses
+// here instead of returning a residue; what is still missing is the multi-cell representation that
+// would let it _succeed_, which is Phase 4's work rather than a wider constant.
+// FIELD-ASSUMPTION: L4-decompose
+// The place values are minted as `two_pow`, so they are only the powers they are meant to be while
+// they have not wrapped the modulus.
+pub fn combine_limbs(b: &mut impl HLEmitter, limbs: &WitnessLimbs) -> ValueId {
+    assert!(
+        !limbs.limbs.is_empty(),
+        "cannot recombine an empty decomposition"
+    );
+    if !combined_limbs_fit_field(b.field(), limbs.limb_bits, limbs.limbs.len()) {
+        unsupported_on_this_field(
+            format_args!(
+                "recombining {} limbs of {} bits reaches 2^{} and so wraps modulo the field, leaving a residue no rangecheck on the result can tell from the value it should have been",
+                limbs.limbs.len(),
+                limbs.limb_bits,
+                limbs.limbs.len() * limbs.limb_bits
+            ),
+            b.field(),
+        );
+    }
+    let mut fields = Vec::with_capacity(limbs.limbs.len());
+    for &limb in &limbs.limbs {
+        fields.push(b.cast_to_field(limb));
+    }
+
+    let mut acc = fields[0];
+    for (i, &limb) in fields.iter().enumerate().skip(1) {
+        let shift = b.field_const(b.field().two_pow(i * limbs.limb_bits));
+        let shifted = b.umul(limb, shift);
+        acc = b.uadd(acc, shifted);
+    }
+    acc
+}
+
+/// Derive the low limb of `value` by subtracting an already-placed high limb, as a field value.
+// FIELD-ASSUMPTION: L4-decompose
+// The place value is minted as `two_pow`; see `combine_limbs`.
+pub fn derive_low_limb(
+    b: &mut impl HLEmitter,
+    value: ValueId,
+    hi_field: ValueId,
+    limb_bits: usize,
+) -> ValueId {
+    let value_field = b.cast_to_field(value);
+    let shift = b.field_const(b.field().two_pow(limb_bits));
+    let shifted_hi = b.umul(hi_field, shift);
+    let lo_field = b.usub(value_field, shifted_hi);
+    b.cast_to(CastTarget::Int(limb_bits), lo_field)
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::compiler::ssa::hlssa::{
+        BinaryArithOpKind, Constant, HLSSA, MAX_SUPPORTED_UNSIGNED_BITS, OpCode,
+        builder::HLSSABuilder,
+    };
+
+    /// `2^64 - 2^32 + 1`. Not a field this compiler can be configured for yet, which is exactly why
+    /// it is written out here: it is the worked example in `docs/field-agnosticism.md`, and the only
+    /// modulus on which the tuning knob makes a visible difference.
+    fn goldilocks() -> BigInt {
+        (BigInt::one() << 64) - (BigInt::one() << 32) + BigInt::one()
+    }
+
+    /// The default budget with `accumulated_products` overridden.
+    fn products(count: u32) -> LimbBudget {
+        LimbBudget {
+            accumulated_products: count,
+        }
+    }
+
+    /// The widest width that is a multiple of `alignment` and whose budgeted product fits `modulus`.
+    ///
+    /// The rule this module deliberately does **not** implement, kept as a local so
+    /// `a_coarser_granularity_would_buy_a_step_but_leave_a_ragged_limb` can state what is being
+    /// given up without offering it as a setting.
+    fn coarser_limb_bits(modulus: &BigInt, alignment: usize, count: u32) -> usize {
+        (alignment..=HOST_LIMB_BITS)
+            .rev()
+            .filter(|w| w % alignment == 0)
+            .find(|&w| {
+                let max_limb = (BigInt::one() << w) - BigInt::one();
+                &max_limb * &max_limb * BigInt::from(count) < *modulus
+            })
+            .expect("goldilocks admits at least a byte-wide limb")
+    }
+
+    #[test]
+    fn bn254_is_capped_by_the_host_not_by_the_field() {
+        // The number the whole of Phase 2 is held to: `h = 64` on bn254 is what keeps every
+        // existing lowering byte-identical.
+        assert_eq!(witness_limb_bits(FieldConfig::bn254()), 64);
+        assert_eq!(witness_half_limb_bits(FieldConfig::bn254()), 32);
+
+        // And it is the cap that binds, not the modulus: bn254 has room for a far wider limb, so
+        // every knob setting short of an absurd accumulation budget gives the same answer.
+        let p = field_modulus(FieldConfig::bn254());
+        for count in [1u32, 2, 16, 1 << 20] {
+            assert_eq!(
+                limb_bits_for_modulus(&p, products(count)),
+                HOST_LIMB_BITS,
+                "bn254 at {count} products"
+            );
+        }
+    }
+
+    #[test]
+    fn goldilocks_gets_a_32_bit_limb_because_a_bare_product_fits() {
+        // The fact a bit-count bound cannot see, and the reason the predicate is stated against the
+        // modulus: the largest 32-bit product clears goldilocks by exactly `2^32`.
+        let p = goldilocks();
+        let max32 = (BigInt::one() << 32) - BigInt::one();
+        assert!(&max32 * &max32 < p, "a bare 32x32 product fits goldilocks");
+        assert_eq!(p.clone() - &max32 * &max32, BigInt::one() << 32);
+
+        // So asking only that `a*b` not wrap answers 32, which is what the default asks ...
+        assert_eq!(limb_bits_for_modulus(&p, products(1)), 32);
+        assert_eq!(limb_bits_for_modulus(&p, LimbBudget::DEFAULT), 32);
+        // ... and asking for room to accumulate a second product drops it to 16, because there is
+        // no power of two in between. This one step is the whole content of the knob on goldilocks,
+        // and the reason `accumulated_products` is the knob worth having.
+        assert_eq!(limb_bits_for_modulus(&p, products(2)), 16);
+    }
+
+    #[test]
+    fn a_coarser_granularity_would_buy_a_step_but_leave_a_ragged_limb() {
+        // The temptation, stated so the decision is on the record rather than implied by an absent
+        // setting: a byte-aligned rule reaches 24 on goldilocks where powers of two stop at 16,
+        // which is four limbs per u96 instead of six.
+        let p = goldilocks();
+        assert_eq!(coarser_limb_bits(&p, 8, 2), 24);
+        assert_eq!(limb_bits_for_modulus(&p, products(2)), 16);
+
+        // And the reason it is not offered: 24 does not divide the widths this compiler lowers, so
+        // every split would first have to widen its operand to a multiple of 24 -- which for a u128
+        // is 144 bits, past the integer type cap. `lookup_sizing` charges the slack on top.
+        assert_ne!(32 % 24, 0);
+        assert_ne!(128 % 24, 0);
+        assert!(128usize.div_ceil(24) * 24 > MAX_SUPPORTED_UNSIGNED_BITS);
+
+        // And nothing is given up at the budget the compiler actually runs: 24 only wins once a
+        // second product has to fit, and at `DEFAULT` the two rules agree on 32, which is a power
+        // of two _and_ byte-aligned. Dropping the granularity knob costs goldilocks nothing.
+        assert_eq!(coarser_limb_bits(&p, 8, 1), 32);
+        assert_eq!(limb_bits_for_modulus(&p, LimbBudget::DEFAULT), 32);
+    }
+
+    #[test]
+    fn the_default_budget_is_the_one_the_compiler_runs_on() {
+        // `witness_limb_bits` is a thin wrapper; pin that it really is the default budget, so a
+        // knob edit cannot move production while leaving the knob tests green.
+        let p = field_modulus(FieldConfig::bn254());
+        assert_eq!(
+            witness_limb_bits(FieldConfig::bn254()),
+            limb_bits_for_modulus(&p, LimbBudget::DEFAULT)
+        );
+        assert_eq!(LimbBudget::DEFAULT.accumulated_products, 1);
+    }
+
+    #[test]
+    fn the_candidate_widths_are_the_powers_of_two_up_to_a_host_word() {
+        let widths = candidate_widths();
+        // The ceiling is not a knob: no budget can ask for a limb wider than a host word.
+        assert_eq!(*widths.first().unwrap(), HOST_LIMB_BITS);
+        // And the list is never empty, which is what makes `limb_bits_for_modulus` total.
+        assert_eq!(*widths.last().unwrap(), NARROWEST_LIMB_BITS);
+        assert!(widths.iter().all(|w| w.is_power_of_two()));
+        assert!(widths.windows(2).all(|w| w[0] > w[1]));
+    }
+
+    #[test]
+    fn a_limb_always_multiplies_inside_the_field_within_its_budget() {
+        // The defining property, checked rather than trusted across every modulus width a field
+        // could plausibly have.
+        let widths = candidate_widths();
+        for b in [LimbBudget::DEFAULT, products(2), products(7)] {
+            for field_bits in 2..=256usize {
+                // A modulus just above the low end of its bit range, which is the hardest case: it
+                // is the smallest prime-sized value a `field_bits`-wide field could carry.
+                let p = (BigInt::one() << (field_bits - 1)) + BigInt::one();
+                let h = limb_bits_for_modulus(&p, b);
+                assert!(
+                    widths.contains(&h),
+                    "{h} not admissible at {field_bits} bits"
+                );
+                assert!(h <= HOST_LIMB_BITS, "at {field_bits} bits");
+
+                let fits = |w: usize| {
+                    let m = (BigInt::one() << w) - BigInt::one();
+                    &m * &m * BigInt::from(b.accumulated_products) < p
+                };
+                // Either the limb is genuinely admissible, or the field is too small for even the
+                // narrowest one and we fell back to it.
+                assert!(fits(h) || h == NARROWEST_LIMB_BITS, "at {field_bits} bits");
+                // And nothing wider was passed over.
+                for &wider in widths.iter().take_while(|&&w| w > h) {
+                    assert!(!fits(wider), "{wider} was skipped at {field_bits} bits");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_power_of_two_limb_divides_every_supported_integer_width() {
+        // Why the granularity is fixed at powers of two: the widths this compiler actually lowers
+        // are powers of two, so a power-of-two limb never leaves a ragged top limb, whatever the
+        // field. See `a_coarser_granularity_would_buy_a_step_but_leave_a_ragged_limb` for the
+        // counter-example, and `analysis::lookup_sizing` for what the residue would cost.
+        for h in candidate_widths() {
+            // Only widths a limb is actually cut out of; a limb wider than the value is one limb.
+            for width in [8usize, 16, 32, 64, 128].into_iter().filter(|&w| w >= h) {
+                assert_eq!(width % h, 0, "a {h}-bit limb straddles a u{width}");
+            }
+        }
+    }
+
+    #[test]
+    fn a_two_limb_schoolbook_packing_asks_more_than_the_budget_does() {
+        // The gap the predicate exists for, driven through the function itself rather than through
+        // a re-derivation of its formula: a field wide enough for `(2^h - 1)^2` -- which is all the
+        // budget asks -- can still be far too narrow for `(2^h - 1)^2 * 2^(h+1)`.
+        let h = 64usize;
+        let just_fits_the_product = (BigInt::one() << 160) + BigInt::one();
+        assert_eq!(
+            limb_bits_for_modulus(&just_fits_the_product, LimbBudget::DEFAULT),
+            h,
+            "the budget's own condition holds at 160 bits"
+        );
+        assert!(!two_limb_packing_fits_modulus(&just_fits_the_product, h));
+
+        // The packing needs about `2^(3h+1)`, and these two powers bracket where it lands. They are
+        // what makes the `h + 1` exponent load-bearing: drop it to `h` and the packing fits a
+        // modulus a whole limb width smaller.
+        assert!(!two_limb_packing_fits_modulus(
+            &(BigInt::one() << (3 * h)),
+            h
+        ));
+        assert!(two_limb_packing_fits_modulus(
+            &(BigInt::one() << (3 * h + 1)),
+            h
+        ));
+
+        // And what `witness_limb_bits` does buy on the field that exists: bn254's limb is
+        // host-capped at 64 and the ~2^193 packing has room to spare -- but only for a width that
+        // really is two limbs, which is the other half of the question.
+        let bn254 = FieldConfig::bn254();
+        assert!(two_limb_product_packing_fits(bn254, 128));
+        assert!(!two_limb_product_packing_fits(bn254, 64), "one limb");
+        assert!(!two_limb_product_packing_fits(bn254, 192), "three limbs");
+    }
+
+    #[test]
+    fn two_spreads_sum_inside_a_field_that_a_bit_count_bound_would_have_refused() {
+        let bn254 = FieldConfig::bn254();
+
+        // The width the half-limb decomposition delivers, and the widths the sub-64 bitwise
+        // dispatch reaches directly: all clear bn254 with room to spare, which is why this guard is
+        // a statement about a narrower field rather than about today's lowering.
+        assert!(spread_sum_fits_field(witness_half_limb_bits(bn254), bn254));
+        for bits in [2usize, 8, 16, 32, 63] {
+            assert!(spread_sum_fits_field(bits, bn254), "{bits} bits");
+        }
+
+        // The boundary on bn254, well past the `U(bits*2)` cast's own reach: the cast is capped at
+        // `MAX_SUPPORTED_UNSIGNED_BITS`, so no width past 64 could have been spread there anyway.
+        assert!(spread_sum_fits_field(127, bn254));
+        assert!(!spread_sum_fits_field(128, bn254));
+        assert!(2 * 65 > MAX_SUPPORTED_UNSIGNED_BITS);
+
+        // Why the bound is stated against the modulus. A spread pair is barely over two thirds of
+        // `2^(2*bits)`, so goldilocks carries a full 32-bit bitwise op -- which is what
+        // `docs/field-agnosticism.md` records -- while `2*bits < field_bits` would have stopped at
+        // 31 and refused it.
+        let p = goldilocks();
+        assert!(spread_sum_fits_modulus(32, &p));
+        assert!(!spread_sum_fits_modulus(33, &p));
+        assert!(2 * 32 >= 64, "the bit-count bound refuses this width");
+
+        // And why it is the sum of *two* spreads rather than one: a modulus can hold a single
+        // 32-bit spread and not the pair, which is the only thing that separates this bound from
+        // the bound on one operand.
+        let holds_one_spread_only = BigInt::one() << 63;
+        assert!(
+            ((BigInt::one() << 64) - BigInt::one()) / 3 < holds_one_spread_only,
+            "one 32-bit spread fits"
+        );
+        assert!(!spread_sum_fits_modulus(32, &holds_one_spread_only));
+    }
+
+    #[test]
+    fn limbs_recombine_into_one_cell_only_while_their_place_values_fit() {
+        let bn254 = FieldConfig::bn254();
+
+        // Every recombination in the tree, at the widths it actually runs at.
+        assert!(combined_limbs_fit_field(bn254, 32, 2), "u64 from halves");
+        assert!(combined_limbs_fit_field(bn254, 64, 2), "u128 from limbs");
+
+        // The boundary is exact rather than approximate: `limb_count` limbs of `limb_bits` reach
+        // `2^(limb_count * limb_bits) - 1`, so a modulus of exactly that power is the last one that
+        // still holds every representative.
+        assert!(combined_limbs_fit_modulus(&(BigInt::one() << 64), 32, 2));
+        assert!(!combined_limbs_fit_modulus(
+            &((BigInt::one() << 64) - BigInt::one()),
+            32,
+            2
+        ));
+
+        // The window the guard exists for, and the reason the limb width alone does not close it:
+        // goldilocks admits a 32-bit limb, and two of them do not recombine.
+        let p = goldilocks();
+        assert_eq!(limb_bits_for_modulus(&p, LimbBudget::DEFAULT), 32);
+        assert!(!combined_limbs_fit_modulus(&p, 32, 2));
+        assert!(combined_limbs_fit_modulus(&p, 32, 1));
+    }
+
+    /// The predicate above is wired into [`combine_limbs`], not merely available beside it.
+    ///
+    /// Unlike the other refusals in the tree this one is reachable on bn254 — not from any lowering
+    /// the compiler has, but from a decomposition wide enough to ask for it, which is what the
+    /// multi-cell work will eventually build.
+    #[test]
+    #[should_panic(expected = "recombining 4 limbs of 64 bits reaches 2^256")]
+    fn a_recombination_too_wide_for_the_field_is_refused_rather_than_wrapped() {
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        let mut sb = HLSSABuilder::new(&mut ssa);
+        sb.modify_function(main_id, |b| {
+            let entry = b.function.get_entry_id();
+            let mut e = b.test_block(entry);
+            let limb = e.int_const(64, 1);
+            combine_limbs(
+                &mut e,
+                &WitnessLimbs {
+                    limb_bits: 64,
+                    limbs: vec![limb; 4],
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn a_three_limb_split_recombines_with_ascending_place_values() {
+        // Every caller in the tree splits into exactly two, so `combine_limbs`' loop past the first
+        // place value -- and the `i * limb_bits` exponent it mints -- has no other coverage.
+        let mut ssa = HLSSA::with_main("main".to_string());
+        let main_id = ssa.get_unique_entrypoint_id();
+        {
+            let mut sb = HLSSABuilder::new(&mut ssa);
+            sb.modify_function(main_id, |b| {
+                let entry = b.function.get_entry_id();
+                let mut e = b.test_block(entry);
+                let value = e.int_const(48, 0x0000_DEAD_BEEF);
+                let limbs = split_into_limbs(&mut e, value, 16, 3);
+                assert_eq!(limbs.limb_bits, 16);
+                assert_eq!(limbs.limbs.len(), 3);
+                combine_limbs(&mut e, &limbs);
+                e.terminate_return(vec![]);
+            });
+        }
+
+        let function = ssa.get_unique_entrypoint();
+        let ops: Vec<&OpCode> = function
+            .get_block(function.get_entry_id())
+            .get_instructions()
+            .collect();
+
+        // The split reads ascending, non-overlapping, equal-width windows.
+        let windows: Vec<(usize, usize)> = ops
+            .iter()
+            .filter_map(|op| match op {
+                OpCode::BitRange { offset, width, .. } => Some((*offset, *width)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(windows, vec![(0, 16), (16, 16), (32, 16)]);
+
+        // And the recombination scales limb `i` by `2^(16i)` -- one multiply fewer than there are
+        // limbs, because limb 0 carries no place value at all.
+        let place_values: Vec<BigInt> = ops
+            .iter()
+            .filter_map(|op| match op {
+                OpCode::BinaryArithOp {
+                    kind: BinaryArithOpKind::UMul,
+                    rhs,
+                    ..
+                } => Some(*rhs),
+                _ => None,
+            })
+            .map(|rhs| match ssa.get_const(rhs).as_deref() {
+                Some(Constant::Field(f)) => field_to_bigint_via_bytes(f),
+                other => panic!("a place value must be a field constant, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            place_values,
+            vec![BigInt::one() << 16, BigInt::one() << 32],
+            "place values must be 2^h and 2^2h, not 2^h twice"
+        );
+    }
+
+    /// The canonical integer behind a field element, as a `BigInt`.
+    fn field_to_bigint_via_bytes(f: &crate::compiler::Field) -> BigInt {
+        use num_bigint::Sign;
+        let bytes: Vec<u8> = f
+            .into_bigint()
+            .0
+            .iter()
+            .flat_map(|limb| limb.to_le_bytes())
+            .collect();
+        BigInt::from_bytes_le(Sign::Plus, &bytes)
+    }
+}

--- a/compiler/src/compiler/passes/shared/mod.rs
+++ b/compiler/src/compiler/passes/shared/mod.rs
@@ -2,8 +2,10 @@
 
 pub mod availability;
 pub mod divmod_guard;
+pub mod limbs;
 pub mod overflow_guard;
 pub mod rewrite_asserts;
 pub mod seq_bounds;
 pub mod shift_guard;
+pub mod unsupported;
 pub mod value_replacements;

--- a/compiler/src/compiler/passes/shared/overflow_guard.rs
+++ b/compiler/src/compiler/passes/shared/overflow_guard.rs
@@ -14,6 +14,7 @@
 
 use crate::compiler::{
     analysis::value_range_analysis::ValueRange,
+    passes::shared::unsupported::unsupported_on_this_field,
     ssa::{
         ValueId,
         hlssa::{
@@ -375,11 +376,14 @@ pub fn abs_as_u(
     // signed cap leaves ample room; on a narrower field this refuses instead. Same construction and
     // same bound as `LowerWitnessBitwiseOps::lower_integer_sext`, which lifts a value into the
     // field the same way.
-    assert!(
-        bits < emitter.field().field_bit_size() as usize,
-        "a {bits}-bit magnitude needs a field wider than {} bits",
-        emitter.field().field_bit_size()
-    );
+    if bits >= emitter.field().field_bit_size() as usize {
+        unsupported_on_this_field(
+            format_args!(
+                "a {bits}-bit magnitude lifts the sign out with `two_pow({bits})`, which has itself wrapped, leaving the magnitude — and every overflow test built on it — silently wrong"
+            ),
+            emitter.field(),
+        );
+    }
 
     let value_field = emitter.cast_to_field(value);
     let sign = emitter.cast_to_field(sign_u1);

--- a/compiler/src/compiler/passes/shared/unsupported.rs
+++ b/compiler/src/compiler/passes/shared/unsupported.rs
@@ -1,0 +1,45 @@
+//! Refusal for the widths the configured field cannot carry.
+//!
+//! Nearly every witness lowering packs a value into a single field element, and each of them
+//! therefore carries a precondition on the field's width. On bn254 all of them hold with room to
+//! spare, but this is not true of every field. Routing those preconditions through one check makes
+//! the set of them a register of what a narrower field would need built.
+
+use std::fmt;
+
+use mavros_artifacts::FieldConfig;
+
+use crate::compiler::passes::shared::limbs::witness_limb_bits;
+
+/// Refuse a lowering that the configured field is too narrow to carry, naming the field.
+///
+/// `attempted` says what was being lowered and which quantity did not fit; the tail added here says
+/// what the field actually offers, so the two halves of the mismatch appear in one message.
+pub fn unsupported_on_this_field(attempted: fmt::Arguments<'_>, field: FieldConfig) -> ! {
+    unimplemented!(
+        "{attempted}. The configured field has a {}-bit modulus and a {}-bit witness limb. This \
+         is a limit of the lowering on this field rather than an internal invariant — see \
+         docs/field-agnosticism.md, Layer 6.",
+        field.field_bit_size(),
+        witness_limb_bits(field),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The half of the message the callers do not write.
+    ///
+    /// On the only configured field every caller's predicate holds, so this is the one property of
+    /// the funnel that can be checked without a second field: that the tail names what the field
+    /// offers, in the units the caller's own half is written in.
+    #[test]
+    #[should_panic(expected = "254-bit modulus and a 64-bit witness limb")]
+    fn the_refusal_names_what_the_field_offers() {
+        unsupported_on_this_field(
+            format_args!("a lowering that does not exist"),
+            FieldConfig::bn254(),
+        );
+    }
+}

--- a/compiler/src/compiler/ssa/hlssa_to_llssa.rs
+++ b/compiler/src/compiler/ssa/hlssa_to_llssa.rs
@@ -4,6 +4,7 @@
 //! MemOp (Bump/Drop) are lowered to explicit memory operations.
 
 use mavros_artifacts::{ConstraintsLayout, TableKind, WitnessLayout};
+use mavros_int_semantics::int_bits::FIELD_LIMB_BITS;
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use crate::{
@@ -1441,15 +1442,15 @@ fn lower_instruction(
 
             // A canonical field value fits in `max_bits` exactly when it is less than 2^max_bits.
             let mut limbs = Vec::with_capacity(4);
-            let active_limb = max_bits / 64;
-            let active_bit = max_bits % 64;
+            let active_limb = max_bits / FIELD_LIMB_BITS;
+            let active_bit = max_bits % FIELD_LIMB_BITS;
             for limb in 0..4 {
                 let value = if limb == active_limb {
                     1_u64 << active_bit
                 } else {
                     0
                 };
-                limbs.push(e.emit_int_const(64, value));
+                limbs.push(e.emit_int_const(FIELD_LIMB_BITS as u32, value));
             }
             let limit_limbs = e.mk_struct(LLStruct::limbs(), limbs);
             let limit = e.field_from_limbs(limit_limbs);
@@ -2044,12 +2045,13 @@ fn lower_to_bits(
             bits_le.push(zero_bit);
             continue;
         }
-        let limb_idx = i / 64;
-        let bit_offset = i % 64;
+        let limb_idx = i / FIELD_LIMB_BITS;
+        let bit_offset = i % FIELD_LIMB_BITS;
         let shifted = if bit_offset == 0 {
             limbs[limb_idx]
         } else {
-            let shift = e.emit_int_const(64, bit_offset as u64);
+            // The shift shares the limb's own width, so it is the field limb.
+            let shift = e.emit_int_const(FIELD_LIMB_BITS as u32, bit_offset as u64);
             e.int_arith(IntArithOp::UShr, limbs[limb_idx], shift)
         };
         bits_le.push(e.truncate(shifted, 1));

--- a/docs/field-agnosticism.md
+++ b/docs/field-agnosticism.md
@@ -306,6 +306,8 @@ that gives each field its own implementation. Nothing here is outstanding P3 wor
       `bit_range`/`sext`/`to_bits`/`not`/`rangecheck`/`to_radix`/spread.
 - [ ] `vm/src/bytecode.rs:1767-1815,1242-1252` — `rngchk`/`to_bytes_be|le`/`truncate_f_to_u` (slice
       `into_bigint().0` limbs).
+- [ ] `compiler/src/compiler/passes/shared/limbs.rs` — `combine_limbs`/`derive_low_limb` place
+      values (`two_pow`).
 - [ ] `compiler/src/compiler/passes/instruction_lowering/witness_bitwise.rs` — bitmask/sign-extend
       via `b.field().two_pow(..)`. The helper is gone (see `L4-two-pow`); what remains is the
       _strategy_, which wraps mod p once the shift reaches the field width (see also
@@ -470,15 +472,37 @@ Let `B = floor(log2 p)` (bn254: 253; goldilocks: 63). For standard widths on gol
   technically be made to fit"); bitwise natural-spread (≤ 32 bits) and shl fit. All **fragile** —
   correct standalone, but a fused `q·divisor + r` reconstruction can tip over.
 - `u64 / u128 / i64`: a bare value's range `≥ p` (`2⁶⁴ − 1 > p`) ⇒ it **cannot be held injectively
-  in one cell**; every recombination into one cell (`combine_u64_fields`, `lower_not`'s `2⁶⁴ − 1`,
-  signed `sign·2⁶⁴` packing) wraps.
+  in one cell**; every recombination into one cell (`shared/limbs.rs`'s `combine_limbs`,
+  `lower_not`'s `2⁶⁴ − 1`, signed `sign·2⁶⁴` packing) wraps.
 
 So on goldilocks standard widths collapse to **{single-field for n ≤ 32, multi-cell for n ≥ 64}**;
 the "operation-strategy-only" band is empty for standard widths. `range_fits_field_injectively`
 (`witness_integer_arith.rs`) already flips correctly on a small field — **the debt is the missing
 FALSE-case codegen**, not the predicate. Today the only FALSE-case path is unsigned u128 mul, and it
-still packs `lo + cross·2⁶⁴ ≈ 2¹⁹³` into one cell (assumes ~193-bit headroom); everything else
-`assert!`/`panic!`s.
+still packs `lo + cross·2ʰ ≈ 2³ʰ⁺¹` into one cell (~2¹⁹³ at the bn254 limb); every other _consumer
+of that predicate_ refuses through the funnel below. Lowerings that never ask it are a separate
+matter — see the list under `L6-int-op-strategy`.
+
+### Refusing On a Narrow Field
+
+The FALSE-case codegen does not exist yet, so every lowering whose precondition the configured field
+fails routes through one funnel: `compiler/src/compiler/passes/shared/unsupported.rs`. It appends
+the field's modulus width and witness limb width to the caller's own description of what did not
+fit, so a refusal names both halves of the mismatch, and the set of its call sites **is** the
+machine-readable half of this register.
+
+The call sites: `witness_bitwise`'s `lower_integer_sext`, `lower_word_bitwise` (spread width) and
+`product_headroom_or_bail`; `witness_integer_arith`'s `lower_unsigned_mul` (both the single-field
+product and the two-limb packing, the latter covering the limb _count_ as well as the packing);
+`lower_signed_addsub` and `lower_signed_mul`; `shared/limbs.rs`'s `combine_limbs` (the
+recombination); `witness_field`'s `to_bits` and `to_radix`; and `shared::overflow_guard`'s
+`abs_as_u`.
+
+Two kinds of neighboring check deliberately stay out: an internal invariant no field choice can
+violate (`bit_range`'s "a field `BitRange` cannot exceed a field element"), and a branch whose
+condition is an integer _type_ cap rather than a field width (`wrap_shifted_product`'s trapping
+fallback, which rejects a witness at proving time rather than refusing every 128-bit `<<` at compile
+time).
 
 **P5 target — integers wider than the field must be _supported_, not rejected.** The end state is a
 **multi-cell representation** (Option A): an integer whose type range is `≥ p` (`n > B`) is carried
@@ -486,19 +510,13 @@ as `⌈n/h⌉` field cells end-to-end (witness layout, `Cast`, VM frame, opcode 
 integer type-system caps (`MAX_SUPPORTED_*_BITS` = 128/64) stay **field-independent** — a goldilocks
 `u128` is just a wider cell vector, exactly as bn254 already carries a u128 value in one cell but
 its 256-bit _product_ across two. Paired with a **schoolbook engine** for the FALSE branch (split
-operands into `h`-bit limbs with `h ≈ (field_bits − guard)/2`, byte-aligned — bn254 `h = 64` keeps
-today byte-identical, goldilocks `h = 16`; in-field partial products `< 2^{2h} < p`;
-column-accumulate with a witnessed, range-checked carry chain; keep the low result limbs). Sequence
-within P5: multi-cell representation → mul engine → add/sub-carry → divmod → bitwise → signed.
-**Transitional scaffold, filed under P5:** converge the scattered FALSE-case `assert!`/`panic!`s
-onto one `unimplemented!("multi-limb — P5")` funnel (byte-identical on bn254; on a small field it
-fails loudly until the multi-cell path lands, rather than silently miscompiling). This is a
-scaffold, **not** a width cap — we are not restricting the supported integer widths on any field. It
-was originally pencilled in as near-term P3 work, but it changes nothing on bn254 (every one of
-those branches is unreachable there, which is what the byte-identical corpus shows) and only earns
-its keep next to the multi-cell representation it warns about, so it belongs with P5's first
-sub-piece rather than with the `FieldConfig` threading. **Dominant risk:** every witnessed
-limb/carry must be range-checked or a malicious prover forges the result.
+operands into `h`-bit limbs, `h` derived from the modulus by
+`compiler/src/compiler/passes/shared/limbs.rs`; in-field partial products; column-accumulate with a
+witnessed, range-checked carry chain; keep the low result limbs).
+
+Sequence within P5: multi-cell representation → mul engine → add/sub-carry → divmod → bitwise →
+signed. **Dominant risk:** every witnessed limb/carry must be range-checked or a malicious prover
+can forge the result.
 
 Two tags, distinct from the constant-swap tags:
 
@@ -507,10 +525,29 @@ Two tags, distinct from the constant-swap tags:
 A single-field arithmetic op assumes its exact result span fits one cell (one `b.mul`/`b.add`, or a
 `two_pow`-based packing). Fix = multi-limb schoolbook / carry-chain lowering in the FALSE branch.
 
-- [ ] `witness_integer_arith.rs` — `lower_unsigned_mul` (single-field product + the ~193-bit u128
-      fallback), `lower_signed_mul` (no fallback), `lower_unsigned_addsub`, `lower_signed_addsub`,
-      `signed_value_from_encoded`/`encode_signed_value` (sign packing), `lower_unsigned_divmod`.
+- [ ] `witness_integer_arith.rs` — `lower_unsigned_mul` (single-field product + the `2³ʰ⁺¹` u128
+      fallback packing), `lower_signed_mul` (no fallback), `lower_unsigned_addsub`,
+      `lower_signed_addsub`, `signed_value_from_encoded`/`encode_signed_value` (sign packing),
+      `lower_unsigned_divmod`.
 - [ ] `witness_bitwise.rs` — `lower_not`, `lower_integer_sext`, `lower_word_bitwise` (spread width).
+
+**Five of these refuse** rather than miscompiling when their span does not fit (see the funnel
+above): `lower_unsigned_mul` on both its paths, `lower_signed_mul`, `lower_signed_addsub`,
+`lower_integer_sext` and `lower_word_bitwise`. What remains for P5 at those five is the FALSE-case
+lowering itself.
+
+**The rest still carry the assumption unchecked**, with only a `FIELD-ASSUMPTION` comment on it, and
+are what to fix first if a narrow field is configured before P5's lowerings exist:
+`lower_unsigned_addsub`, `lower_not`, and the `signed_value_from_encoded`/`encode_signed_value` sign
+packing. `lower_unsigned_divmod` is a mixture: its 128-bit path reconstructs `q·divisor + r` by
+emitting `UMul`/`UAdd` **ops**, which this same pass re-lowers, so it inherits the mul's refusal and
+the add's gap; its narrow path multiplies in the field directly and has no check of its own.
+
+Note that the funnel's condition is per-site, because `witness_limb_bits` certifies only that a bare
+`a·b` fits. A lowering that additionally scales a column by a place value asks
+`two_limb_product_packing_fits`, one that spreads asks `spread_sum_fits_field`, and one that
+recombines asks `combined_limbs_fit_field` — all three in `shared/limbs.rs`, alongside the limb rule
+they each strengthen.
 
 ### `L6-int-representation` — Value Range `≥ p` Assumed to Fit One Cell (Representation, P5 multi-cell)
 
@@ -522,9 +559,20 @@ serde). Wide integers are supported, not capped away.
 - [ ] `compiler/src/compiler/ssa/hlssa/type_system.rs:5-6` — `MAX_SUPPORTED_UNSIGNED_BITS` /
       `MAX_SUPPORTED_SIGNED_BITS` stay field-independent (the int-type caps); the multi-cell
       representation carries any width `> B` on a small field.
-- [ ] `witness_integer_arith.rs` — `split_u128_value` (fixed 2×64 layout; limb width becomes `h`).
-- [ ] `witness_bitwise.rs` — `combine_u32_limbs` / `combine_u64_fields` (recombine into one cell;
-      `extract_u128_limbs`/`decompose_u64_input` limb widths must derive from the field size).
+- [ ] `passes/shared/limbs.rs` — `combine_limbs` (recombines `⌈n/h⌉` limbs into **one** cell). The
+      limb _widths_ are done: `witness_limb_bits` derives `h` from the modulus, and every splitter
+      and place value in the tree now asks it — though asking it is not on its own a proof that the
+      _result_ fits, which is why the packing, spread and recombination sites carry their own
+      predicates. `combine_limbs` now refuses through the funnel when `⌈n/h⌉` limbs do not fit one
+      cell, so the wrap is not reachable; what is left is the multi-cell target that would let it
+      **succeed** instead, and the limb count on the way there — a decomposition wider than two
+      limbs has nowhere to go, so `WitnessLimbs::pair` refuses rather than truncates.
+- [ ] `witness_integer_arith.rs` — `split_u128_value`'s caller `lower_unsigned_mul` reads the split
+      as a pair.
+- [ ] `witness_bitwise.rs` — the `bits == 64` / `bits == 128` bitwise dispatch is a **type**-width
+      dispatch, so on a narrower field it routes a `u64` to a lowering that no longer suits it.
+      `decompose_into_half_limbs` asserts on exactly that mismatch, so the miscompile is not
+      reachable, but the dispatch still has to grow a `⌈n/h⌉` arm before a narrow field works.
 
 The `value_range_analysis.rs` interval domain is over `BigInt` and stays correct on any field — it
 already produces the exact spans the FALSE-case codegen consumes (no new marker; only `field_top` /

--- a/int-semantics/src/int_bits.rs
+++ b/int-semantics/src/int_bits.rs
@@ -9,11 +9,17 @@ use thiserror::Error;
 
 use crate::{CmpOp, MAX_BITS, MAX_SIGNED_BITS, SignedValue, check_widths, mask};
 
+// HOST LIMB
+// ================================================================================================
+
+/// The width of one limb of an [`IntBits`] pattern, and of one integer cell in a VM frame.
+pub const HOST_LIMB_BITS: usize = u64::BITS as usize;
+
 // INTEGER BIT PATTERN
 // ================================================================================================
 
 /// A `bits`-wide two's-complement pattern: exactly [`IntBits::limbs_for_bits`] little-endian
-/// 64-bit limbs, with every bit at or above `bits` set to zero.
+/// [`HOST_LIMB_BITS`]-wide limbs, with every bit at or above `bits` set to zero.
 ///
 /// It has no [`Ord`] implementation because it is a raw bit interpretation and there are two valid
 /// readings of ordering for this type. [`IntBits::compare`] should be used to choose a reading.
@@ -56,7 +62,7 @@ impl IntBits {
         let mut limbs = vec![0u64; count];
         limbs[0] = value as u64;
         if count > 1 {
-            limbs[1] = (value >> 64) as u64;
+            limbs[1] = (value >> HOST_LIMB_BITS) as u64;
         }
         Self::normalized(bits, limbs)
     }
@@ -212,11 +218,11 @@ impl IntBits {
         &self.limbs
     }
 
-    /// The number of 64-bit limbs a `bits`-wide pattern occupies.
+    /// The number of [`HOST_LIMB_BITS`]-wide limbs a `bits`-wide pattern occupies.
     ///
-    /// The host limb is 64 bits and that is fixed by the machine, not by the field: this is the
-    /// quantity `int_cell_count` reserves in a VM frame and `for_each_constant_word` emits. The
-    /// _field_ limb is a different and narrower thing, derived from the field's own width.
+    /// [`HOST_LIMB_BITS`] is fixed by the machine and not by the field: this is the quantity
+    /// `int_cell_count` reserves in a VM frame and `for_each_constant_word` emits. The _field_ limb
+    /// is a different and narrower thing, derived from the field's own width.
     ///
     /// # Panics
     ///
@@ -224,7 +230,7 @@ impl IntBits {
     #[must_use]
     pub fn limbs_for_bits(bits: usize) -> usize {
         assert!(bits > 0, "an integer pattern is at least one bit wide");
-        bits.div_ceil(64)
+        bits.div_ceil(HOST_LIMB_BITS)
     }
 
     /// How many limbs this pattern occupies.
@@ -267,7 +273,7 @@ impl IntBits {
         if index >= self.bits {
             return None;
         }
-        Some((self.limbs[index / 64] >> (index % 64)) & 1 == 1)
+        Some((self.limbs[index / HOST_LIMB_BITS] >> (index % HOST_LIMB_BITS)) & 1 == 1)
     }
 }
 
@@ -359,19 +365,19 @@ impl IntBits {
         if amount >= self.bits {
             return Self::zero(self.bits);
         }
-        let (whole, part) = (amount / 64, amount % 64);
+        let (whole, part) = (amount / HOST_LIMB_BITS, amount % HOST_LIMB_BITS);
         let mut out = vec![0u64; self.limbs.len()];
         for (i, &limb) in self.limbs.iter().enumerate() {
             let Some(target) = out.get_mut(i + whole) else {
                 break;
             };
             *target |= limb << part;
-            // A shift by a whole limb is `limb << 64`, which is undefined rather than zero, so the
-            // carry into the next limb is guarded rather than written as `limb >> (64 - part)`.
+            // A shift by a whole limb is `limb << HOST_LIMB_BITS`, which is undefined rather than
+            // zero, so the carry into the next limb is guarded rather than written directly.
             if part > 0
                 && let Some(next) = out.get_mut(i + whole + 1)
             {
-                *next |= limb >> (64 - part);
+                *next |= limb >> (HOST_LIMB_BITS - part);
             }
         }
         Self::normalized(self.bits, out)
@@ -383,7 +389,7 @@ impl IntBits {
         if amount >= self.bits {
             return Self::zero(self.bits);
         }
-        let (whole, part) = (amount / 64, amount % 64);
+        let (whole, part) = (amount / HOST_LIMB_BITS, amount % HOST_LIMB_BITS);
         let mut out = vec![0u64; self.limbs.len()];
         for i in 0..self.limbs.len() {
             let Some(&limb) = self.limbs.get(i + whole) else {
@@ -393,7 +399,7 @@ impl IntBits {
             if part > 0
                 && let Some(&next) = self.limbs.get(i + whole + 1)
             {
-                out[i] |= next << (64 - part);
+                out[i] |= next << (HOST_LIMB_BITS - part);
             }
         }
         Self::normalized(self.bits, out)
@@ -776,7 +782,7 @@ impl IntBits {
         }
         let lo = self.limbs.first().copied().unwrap_or(0);
         let hi = self.limbs.get(1).copied().unwrap_or(0);
-        Ok(u128::from(lo) | (u128::from(hi) << 64))
+        Ok(u128::from(lo) | (u128::from(hi) << HOST_LIMB_BITS))
     }
 }
 
@@ -867,11 +873,8 @@ pub struct DoesNotFit {
 // ================================================================================================
 
 /// The mask the top limb of a `bits`-wide pattern carries.
-///
-/// A width that is a whole number of limbs has a full top limb; `bits % 64 == 0` is that case and
-/// not an empty one, which is why it cannot be written as `(1 << (bits % 64)) - 1`.
 const fn top_limb_mask(bits: usize) -> u64 {
-    match bits % 64 {
+    match bits % HOST_LIMB_BITS {
         0 => u64::MAX,
         rest => (1u64 << rest) - 1,
     }
@@ -890,12 +893,24 @@ mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
+    #[test]
+    fn the_boundary_widths_straddle_the_top_limb_as_documented() {
+        // `16384` is exactly 256 limbs, so its top limb is full ...
+        assert_eq!(IntBits::limbs_for_bits(16384), 256);
+        assert_eq!(top_limb_mask(16384), u64::MAX);
+
+        // ... and `16383` is the widest width that shares that limb count with a partial top.
+        assert_eq!(IntBits::limbs_for_bits(16383), 256);
+        assert_ne!(top_limb_mask(16383), u64::MAX);
+        assert_eq!(IntBits::limbs_for_bits(16385), 257);
+    }
+
     /// Widths worth constructing at, chosen for their top limbs.
     ///
     /// `16383` and `16384` are the pair that matters most and the reason both are here: `16384` is
-    /// exactly 256 limbs, so its top limb is full and every `bits % 64` special case vanishes,
-    /// while `16383` is the widest width whose top limb is partial. They occupy the same number of
-    /// limbs, so a test that carries only one of them is testing half the boundary.
+    /// exactly 256 limbs, so its top limb is full and every `bits % HOST_LIMB_BITS` special case
+    /// vanishes, while `16383` is the widest width whose top limb is partial. They occupy the same
+    /// number of limbs, so a test that carries only one of them is testing half the boundary.
     const WIDTHS: &[usize] = &[
         1, 2, 3, 7, 8, 63, 64, 65, 96, 127, 128, 129, 191, 192, 193, 1000, 16383, 16384,
     ];


### PR DESCRIPTION
This commit introduces a centralized, field-independent abstraction for value limbs in the compiler, serving as a basis for the future encoding of arbitrary integers.

The compiler no longer assumes that limbs can be 64 bits wide (which is true of bn254 but not of other fields like goldilocks), and calls out the sites where we still make assumptions related to limb sizes.

Partial work on #120.